### PR TITLE
fix(anta.cli): Improve 'anta exec snapshot'

### DIFF
--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -45,6 +45,7 @@ def clear_counters(ctx: click.Context, log_level: str, tags: str) -> None:
 
 
 def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> str:  # pylint: disable=unused-argument
+    """Build directory name for command snapshots, including current time"""
     return f"{value}_{datetime.today().strftime('%Y-%m-%d_%H%M%S')}"
 
 

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -52,10 +52,10 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
 @click.command()
 @click.pass_context
 # Generic options
-@click.option('--tags', '-t', default=DEFAULT_TAG, help='List of tags using coma as separator: tag1,tag2,tag3', type=str, required=False)
+@click.option('--tags', '-t', default=DEFAULT_TAG, help='List of tags using coma as separator: tag1,tag2,tag3', type=str)
 @click.option('--commands-list', '-c', show_envvar=True, type=click.Path(), help='File with list of commands to grab', required=True)
 @click.option('--output-directory', '-output', '-o', show_envvar=True, type=click.Path(), help='Path where to save commands output',
-              default='anta_snapshot', callback=_get_snapshot_dir, required=True)
+              default='anta_snapshot', callback=_get_snapshot_dir)
 # Debug stuf
 @click.option('--log-level', '--log', help='Logging level of the command', default='info',
               type=click.Choice(['debug', 'info', 'warning', 'critical'], case_sensitive=False))

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -8,6 +8,7 @@ Commands for Anta CLI to execute EOS commands.
 import asyncio
 import logging
 import sys
+from datetime import datetime
 
 import click
 from yaml import safe_load
@@ -43,12 +44,17 @@ def clear_counters(ctx: click.Context, log_level: str, tags: str) -> None:
         )
 
 
+def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> str:  # pylint: disable=unused-argument
+    return f"{value}_{datetime.today().strftime('%Y-%m-%d_%H%M%S')}"
+
+
 @click.command()
 @click.pass_context
 # Generic options
 @click.option('--tags', '-t', default=DEFAULT_TAG, help='List of tags using coma as separator: tag1,tag2,tag3', type=str, required=False)
 @click.option('--commands-list', '-c', show_envvar=True, type=click.Path(), help='File with list of commands to grab', required=True)
-@click.option('--output-directory', '-outut', '-o', show_envvar=True, type=click.Path(), help='Path where to save commands output', required=False)
+@click.option('--output-directory', '-output', '-o', show_envvar=True, type=click.Path(), help='Path where to save commands output',
+              default='anta_snapshot', callback=_get_snapshot_dir, required=True)
 # Debug stuf
 @click.option('--log-level', '--log', help='Logging level of the command', default='info',
               type=click.Choice(['debug', 'info', 'warning', 'critical'], case_sensitive=False))

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -9,8 +9,10 @@ import asyncio
 import logging
 import os
 import traceback
+import itertools
+from pathlib import Path
 from time import gmtime, strftime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Literal
 
 from aioeapi import EapiCommandError
 from scp import SCPClient
@@ -44,80 +46,50 @@ async def clear_counters_utils(anta_inventory: AntaInventory, enable_pass: str, 
             )
             logger.debug(traceback.format_exc())
 
-    logger.info('Reading inventory')
+    logger.info("Connecting to devices...")
     await anta_inventory.connect_inventory()
     devices = anta_inventory.get_inventory(established_only=True, tags=tags)
     logger.info('Execute command to remote devices')
     await asyncio.gather(*(clear(device) for device in devices))
 
 
-def device_directories_snapshot(
-    device: InventoryDevice, root_dir: str
-) -> Tuple[str, str, str, str]:
-    """
-    Create device directories
-    """
-    cwd = os.getcwd()
-    output_directory = os.path.dirname(f"{cwd}/{root_dir}/")
-    device_directory = f"{output_directory}/{device.name}"
-    json_directory = f"{device_directory}/json"
-    text_directory = f"{device_directory}/text"
-    for directory in [
-        output_directory,
-        device_directory,
-        json_directory,
-        text_directory,
-    ]:
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-    return output_directory, device_directory, json_directory, text_directory
-
-
 async def collect_commands(inv: AntaInventory,  enable_pass: str, commands: Dict[str, str], root_dir: str, tags: List[str]) -> None:
     """
     Collect EOS commands
     """
+    async def collect(dev: InventoryDevice, command: str, outformat: Literal['json', 'text']) -> None:
+        try:
+            outdir = Path() / root_dir / dev.name / outformat
+            outdir.mkdir(parents=True, exist_ok=True)
+            outfile = outdir / command
+            result = await dev.session.cli(
+                            commands=[
+                                {"cmd": "enable", "input": enable_pass}, command],
+                            ofmt=outformat
+                        )
+            with outfile.open(mode="w", encoding="UTF-8") as f:
+                f.write(str(result[1]))
+            logger.info(f"Collected command '{command}' from device {dev.name} ({dev.hw_model})")
+        except EapiCommandError as e:
+            logger.error(f"Command failed on {dev.name}: {e.errmsg}")
+        # In this case we want to catch all exceptions
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"Could not collect commands on device {dev.name}")
+            logger.debug(
+                f"Exception raised for device {dev.name} - {type(e).__name__}: {str(e)}"
+            )
+            logger.debug(traceback.format_exc())
+
     logger.info("Connecting to devices...")
     await inv.connect_inventory()
     devices = inv.get_inventory(established_only=True, tags=tags)
-    for device in devices:  # TODO: should use asyncio.gather instead of a loop.
-        logger.info("----")
-        logger.info(f"Collecting show commands output to device {device.name}")
-        output_dir = device_directories_snapshot(device, root_dir)
-        try:
-            if "json_format" in commands:
-                for command in commands["json_format"]:
-                    result = await device.session.cli(
-                        commands=[
-                            {"cmd": "enable", "input": enable_pass}, command],
-                        ofmt='json'
-                    )
-                    outfile = f"{output_dir[2]}/{command}"
-                    with open(outfile, "w", encoding="UTF-8") as out_fd:
-                        out_fd.write(str(result[1]))
-                    logger.info(
-                        f"  * Collected command '{command}' on {device.name}")
-            if "text_format" in commands:
-                for command in commands["text_format"]:
-                    result = await device.session.cli(
-                        commands=[
-                            {"cmd": "enable", "input": enable_pass}, command],
-                        ofmt='text'
-                    )
-                    outfile = f"{output_dir[3]}/{command}"
-                    with open(outfile, "w", encoding="UTF-8") as out_fd:
-                        out_fd.write(f'{device.name}# {command}\n\r')
-                        out_fd.write(result[1])
-                    logger.info(
-                        f"  * Collected command '{command}' on {device.name}")
-        except EapiCommandError as e:
-            logger.error(f"Command failed on {device.name}: {e.errmsg}")
-        except Exception as e:  # pylint: disable=broad-except
-            logger.error(f"Could not collect commands on device {device.name}")
-            logger.debug(
-                f"Exception raised for device {device.name} - {type(e).__name__}: {str(e)}"
-            )
-            logger.debug(traceback.format_exc())
+    logger.info('Collecting commands from remote devices')
+    coros = [collect(device, command, 'json') for device, command in itertools.product(devices, commands["json_format"])]
+    coros += [collect(device, command, 'text') for device, command in itertools.product(devices, commands["text_format"])]
+    res = await asyncio.gather(*coros, return_exceptions=True)
+    for r in res:
+        if isinstance(r, Exception):
+            logger.error(f"Error when running tests: {r.__class__.__name__}: {r}")
 
 
 def device_directories_show_tech_support(dev: str, root_dir: str) -> str:


### PR DESCRIPTION
- Modified `collect_commands()` logic to use `asyncio.gather()` instead of the synchronous logic with a for loop.
- The `--output-directory` option of the `anta exec snapshot` command could be None if not provided and created a folder with that name. Added a default value and a timestamp to avoid overriding previous command collections.
