### PR TITLE
refactor(anta.tests): Refactor VXLAN tests

### DIFF
--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -2,6 +2,9 @@
 Test functions related to VXLAN
 """
 import logging
+from typing import Any, Dict, cast
+
+from anta.models import AntaTest, AntaTestCommand
 
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult
@@ -10,38 +13,32 @@ from anta.tests import anta_test
 logger = logging.getLogger(__name__)
 
 
-@anta_test
-async def verify_vxlan(device: InventoryDevice, result: TestResult) -> TestResult:
+class VerifyVxlan(AntaTest):
     """
-    Verifies the interface vxlan 1 status is up/up.
-
-    Args:
-        device (InventoryDevice): InventoryDevice instance containing all devices information.
-
-    Returns:
-        TestResult instance with
-        * result = "unset" if the test has not been executed
-        * result = "success" if vxlan1 interface is UP UP
-        * result = "failure" otherwise.
-        * result = "error" if any exception is caught
-
+    Verifies if Vxlan1 interface is configured, and is up/up
     """
-    response = await device.session.cli(command="show interfaces description", ofmt="json")
-    logger.debug(f"query result is: {response}")
 
-    response_data = response["interfaceDescriptions"]
+    name = "verify_vxlan"
+    description = "Verifies Vxlan1 status"
+    categories = ["mlag"]
+    commands = [AntaTestCommand(command="show interfaces description", ofmt="json")]
 
-    if "Vxlan1" not in response_data:
-        result.is_failure("No interface VXLAN 1 detected.")
-    else:
-        protocol_status = response_data["Vxlan1"]["lineProtocolStatus"]
-        interface_status = response_data["Vxlan1"]["interfaceStatus"]
-        if protocol_status == "up" and interface_status == "up":
-            result.is_success()
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """Run VerifyVxlan validation"""
+        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
+        self.logger.debug(f"dataset is: {command_output}")
+
+        if "Vxlan1" not in command_output['interfaceDescriptions']:
+            self.result.is_skipped("Vxlan1 interface is not configured")
+        elif (
+            command_output['interfaceDescriptions']['Vxlan1']['lineProtocolStatus'] == "up"
+            and command_output['interfaceDescriptions']['Vxlan1']['interfaceStatus'] == "up"
+        ):
+            self.result.is_success()
         else:
-            result.messages.append(f"Vxlan interface is {protocol_status}/{interface_status}.")
-
-    return result
+            self.result.is_failure(f"Vxlan1 interface is {command_output['interfaceDescriptions']['Vxlan1']['lineProtocolStatus']}/{command_output['interfaceDescriptions']['Vxlan1']['interfaceStatus']}")
 
 
 @anta_test

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -6,10 +6,6 @@ from typing import Any, Dict, cast
 
 from anta.models import AntaTest, AntaTestCommand
 
-from anta.inventory.models import InventoryDevice
-from anta.result_manager.models import TestResult
-from anta.tests import anta_test
-
 logger = logging.getLogger(__name__)
 
 
@@ -30,15 +26,18 @@ class VerifyVxlan(AntaTest):
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
         self.logger.debug(f"dataset is: {command_output}")
 
-        if "Vxlan1" not in command_output['interfaceDescriptions']:
+        if "Vxlan1" not in command_output["interfaceDescriptions"]:
             self.result.is_skipped("Vxlan1 interface is not configured")
         elif (
-            command_output['interfaceDescriptions']['Vxlan1']['lineProtocolStatus'] == "up"
-            and command_output['interfaceDescriptions']['Vxlan1']['interfaceStatus'] == "up"
+            command_output["interfaceDescriptions"]["Vxlan1"]["lineProtocolStatus"] == "up"
+            and command_output["interfaceDescriptions"]["Vxlan1"]["interfaceStatus"] == "up"
         ):
             self.result.is_success()
         else:
-            self.result.is_failure(f"Vxlan1 interface is {command_output['interfaceDescriptions']['Vxlan1']['lineProtocolStatus']}/{command_output['interfaceDescriptions']['Vxlan1']['interfaceStatus']}")  # noqa: E501
+            self.result.is_failure(
+                f"Vxlan1 interface is {command_output['interfaceDescriptions']['Vxlan1']['lineProtocolStatus']}"
+                f"/{command_output['interfaceDescriptions']['Vxlan1']['interfaceStatus']}"
+            )
 
 
 class VerifyVxlanConfigSanity(AntaTest):
@@ -46,8 +45,8 @@ class VerifyVxlanConfigSanity(AntaTest):
     Verifies that there are no VXLAN config-sanity issues flagged
     """
 
-    name = "verify_vxlan"
-    description = "Verifies Vxlan1 status"
+    name = "verify_vxlan_config_sanity"
+    description = "Verifies VXLAN config-sanity"
     categories = ["vxlan"]
     commands = [AntaTestCommand(command="show vxlan config-sanity", ofmt="json")]
 
@@ -59,11 +58,12 @@ class VerifyVxlanConfigSanity(AntaTest):
         self.logger.debug(f"dataset is: {command_output}")
 
         failed_categories = {
-            category: content for category, content in command_output['categories'].items()  # noqa: E501
+            category: content
+            for category, content in command_output["categories"].items()
             if category in ["localVtep", "mlag", "pd"] and content["allCheckPass"] is not True
         }
 
-        if len(command_output['categories']) == 0:
+        if len(command_output["categories"]) == 0:
             self.result.is_skipped("VXLAN is not configured on this device")
         elif len(failed_categories) > 0:
             self.result.is_failure(f"Vxlan config sanity check is not passing: {failed_categories}")

--- a/tests/units/anta_tests/vxlan/data.py
+++ b/tests/units/anta_tests/vxlan/data.py
@@ -1,0 +1,86 @@
+"""Test inputs for anta.tests.vxlan"""
+
+from typing import Any, Dict, List
+
+INPUT_VXLAN_STATUS: List[Dict[str, Any]] = [
+    {
+        "name": "success",
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Vxlan1": {
+                        "lineProtocolStatus": "up",
+                        "interfaceStatus": "up"
+                    }
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "success",
+        "expected_messages": []
+    },
+    {
+        "name": "skipped",
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Loopback0": {
+                        "lineProtocolStatus": "up",
+                        "interfaceStatus": "up"
+                    }
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "skipped",
+        "expected_messages": ["Vxlan1 interface is not configured"]
+    },
+    {
+        "name": "failure",
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Vxlan1": {
+                        "lineProtocolStatus": "down",
+                        "interfaceStatus": "up"
+                    }
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "failure",
+        "expected_messages": ["Vxlan1 interface is down/up"]
+    },
+    {
+        "name": "failure",
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Vxlan1": {
+                        "lineProtocolStatus": "up",
+                        "interfaceStatus": "down"
+                    }
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "failure",
+        "expected_messages": ["Vxlan1 interface is up/down"]
+    },
+    {
+        "name": "failure",
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Vxlan1": {
+                        "lineProtocolStatus": "down",
+                        "interfaceStatus": "down"
+                    }
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "failure",
+        "expected_messages": ["Vxlan1 interface is down/down"]
+    },
+]

--- a/tests/units/anta_tests/vxlan/data.py
+++ b/tests/units/anta_tests/vxlan/data.py
@@ -228,7 +228,7 @@ INPUT_VXLAN_CONFIG_SANITY: List[Dict[str, Any]] = [
                         ]
                     }
                 },
-                "warnings": [ ]
+                "warnings": []
 
             }
         ],
@@ -387,7 +387,7 @@ INPUT_VXLAN_CONFIG_SANITY: List[Dict[str, Any]] = [
         ],
         "side_effect": [],
         "expected_result": "failure",
-        "expected_messages": ["Vxlan config sanity check is not passing: {'localVtep': {'description': 'Local VTEP Configuration Check', 'allCheckPass': False, 'detail': '', 'hasWarning': True, 'items': [{'name': 'Loopback IP Address', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VLAN-VNI Map', 'checkPass': False, 'hasWarning': False, 'detail': 'No VLAN-VNI mapping in Vxlan1'}, {'name': 'Flood List', 'checkPass': False, 'hasWarning': True, 'detail': 'No VXLAN VLANs in Vxlan1'}, {'name': 'Routing', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VNI VRF ACL', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VRF-VNI Dynamic VLAN', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'Decap VRF-VNI Map', 'checkPass': True, 'hasWarning': False, 'detail': ''}]}}"]
+        "expected_messages": ["Vxlan config sanity check is not passing: {'localVtep': {'description': 'Local VTEP Configuration Check', 'allCheckPass': False, 'detail': '', 'hasWarning': True, 'items': [{'name': 'Loopback IP Address', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VLAN-VNI Map', 'checkPass': False, 'hasWarning': False, 'detail': 'No VLAN-VNI mapping in Vxlan1'}, {'name': 'Flood List', 'checkPass': False, 'hasWarning': True, 'detail': 'No VXLAN VLANs in Vxlan1'}, {'name': 'Routing', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VNI VRF ACL', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VRF-VNI Dynamic VLAN', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'Decap VRF-VNI Map', 'checkPass': True, 'hasWarning': False, 'detail': ''}]}}"]  # noqa: E501
     },
     {
         "name": "skipped",

--- a/tests/units/anta_tests/vxlan/data.py
+++ b/tests/units/anta_tests/vxlan/data.py
@@ -84,3 +84,321 @@ INPUT_VXLAN_STATUS: List[Dict[str, Any]] = [
         "expected_messages": ["Vxlan1 interface is down/down"]
     },
 ]
+
+INPUT_VXLAN_CONFIG_SANITY: List[Dict[str, Any]] = [
+    {
+        "name": "success",
+        "eos_data": [
+            {
+                "categories": {
+                    "localVtep": {
+                        "description": "Local VTEP Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "Loopback IP Address",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VLAN-VNI Map",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Flood List",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Routing",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VNI VRF ACL",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VRF-VNI Dynamic VLAN",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Decap VRF-VNI Map",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    },
+                    "remoteVtep": {
+                        "description": "Remote VTEP Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "Remote VTEP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    },
+                    "pd": {
+                        "description": "Platform Dependent Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "VXLAN Bridging",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VXLAN Routing",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": "VXLAN Routing not enabled"
+                            }
+                        ]
+                    },
+                    "cvx": {
+                        "description": "CVX Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "CVX Server",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": "Not in controller client mode"
+                            }
+                        ]
+                    },
+                    "mlag": {
+                        "description": "MLAG Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "Run 'show mlag config-sanity' to verify MLAG config",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "Peer VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "MLAG VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Virtual VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Peer VLAN-VNI",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "MLAG Inactive State",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    }
+                },
+                "warnings": [ ]
+
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "success",
+        "expected_messages": []
+    },
+    {
+        "name": "failure",
+        "eos_data": [
+            {
+
+                "categories": {
+                    "localVtep": {
+                        "description": "Local VTEP Configuration Check",
+                        "allCheckPass": False,
+                        "detail": "",
+                        "hasWarning": True,
+                        "items": [
+                            {
+                                "name": "Loopback IP Address",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VLAN-VNI Map",
+                                "checkPass": False,
+                                "hasWarning": False,
+                                "detail": "No VLAN-VNI mapping in Vxlan1"
+                            },
+                            {
+                                "name": "Flood List",
+                                "checkPass": False,
+                                "hasWarning": True,
+                                "detail": "No VXLAN VLANs in Vxlan1"
+                            },
+                            {
+                                "name": "Routing",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VNI VRF ACL",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VRF-VNI Dynamic VLAN",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Decap VRF-VNI Map",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    },
+                    "remoteVtep": {
+                        "description": "Remote VTEP Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "Remote VTEP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    },
+                    "pd": {
+                        "description": "Platform Dependent Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "VXLAN Bridging",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "VXLAN Routing",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": "VXLAN Routing not enabled"
+                            }
+                        ]
+                    },
+                    "cvx": {
+                        "description": "CVX Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "CVX Server",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": "Not in controller client mode"
+                            }
+                        ]
+                    },
+                    "mlag": {
+                        "description": "MLAG Configuration Check",
+                        "allCheckPass": True,
+                        "detail": "Run 'show mlag config-sanity' to verify MLAG config",
+                        "hasWarning": False,
+                        "items": [
+                            {
+                                "name": "Peer VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "MLAG VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Virtual VTEP IP",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "Peer VLAN-VNI",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            },
+                            {
+                                "name": "MLAG Inactive State",
+                                "checkPass": True,
+                                "hasWarning": False,
+                                "detail": ""
+                            }
+                        ]
+                    }
+                },
+                "warnings": [
+                    "Your configuration contains warnings. This does not mean misconfigurations. But you may wish to re-check your configurations."
+                ]
+
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "failure",
+        "expected_messages": ["Vxlan config sanity check is not passing: {'localVtep': {'description': 'Local VTEP Configuration Check', 'allCheckPass': False, 'detail': '', 'hasWarning': True, 'items': [{'name': 'Loopback IP Address', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VLAN-VNI Map', 'checkPass': False, 'hasWarning': False, 'detail': 'No VLAN-VNI mapping in Vxlan1'}, {'name': 'Flood List', 'checkPass': False, 'hasWarning': True, 'detail': 'No VXLAN VLANs in Vxlan1'}, {'name': 'Routing', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VNI VRF ACL', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'VRF-VNI Dynamic VLAN', 'checkPass': True, 'hasWarning': False, 'detail': ''}, {'name': 'Decap VRF-VNI Map', 'checkPass': True, 'hasWarning': False, 'detail': ''}]}}"]
+    },
+    {
+        "name": "skipped",
+        "eos_data": [
+            {
+                "categories": {}
+
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "skipped",
+        "expected_messages": ["VXLAN is not configured on this device"]
+    },
+]

--- a/tests/units/anta_tests/vxlan/test_exc.py
+++ b/tests/units/anta_tests/vxlan/test_exc.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for anta.tests.mlag.py
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from anta.tests.vxlan import VerifyVxlan
+from tests.lib.utils import generate_test_ids_list
+
+from .data import INPUT_VXLAN_STATUS
+
+
+@pytest.mark.parametrize("test_data", INPUT_VXLAN_STATUS, ids=generate_test_ids_list(INPUT_VXLAN_STATUS))
+def test_VerifyVxlan(mocked_device: MagicMock, test_data: Any) -> None:
+    """Check VerifyVxlan"""
+
+    logging.info(f"Mocked device is: {mocked_device.host}")
+    logging.info(f"Mocked HW is: {mocked_device.hw_model}")
+
+    test = VerifyVxlan(mocked_device, eos_data=test_data["eos_data"])
+    asyncio.run(test.test())
+    logging.info(f"test result is: {test.result}")
+
+    assert str(test.result.name) == mocked_device.name
+    assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]

--- a/tests/units/anta_tests/vxlan/test_exc.py
+++ b/tests/units/anta_tests/vxlan/test_exc.py
@@ -15,7 +15,7 @@ import pytest
 from anta.tests.vxlan import VerifyVxlan, VerifyVxlanConfigSanity
 from tests.lib.utils import generate_test_ids_list
 
-from .data import INPUT_VXLAN_STATUS, INPUT_VXLAN_CONFIG_SANITY
+from .data import INPUT_VXLAN_CONFIG_SANITY, INPUT_VXLAN_STATUS
 
 
 @pytest.mark.parametrize("test_data", INPUT_VXLAN_STATUS, ids=generate_test_ids_list(INPUT_VXLAN_STATUS))

--- a/tests/units/anta_tests/vxlan/test_exc.py
+++ b/tests/units/anta_tests/vxlan/test_exc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests for anta.tests.vxlan.py
 """

--- a/tests/units/anta_tests/vxlan/test_exc.py
+++ b/tests/units/anta_tests/vxlan/test_exc.py
@@ -12,10 +12,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from anta.tests.vxlan import VerifyVxlan
+from anta.tests.vxlan import VerifyVxlan, VerifyVxlanConfigSanity
 from tests.lib.utils import generate_test_ids_list
 
-from .data import INPUT_VXLAN_STATUS
+from .data import INPUT_VXLAN_STATUS, INPUT_VXLAN_CONFIG_SANITY
 
 
 @pytest.mark.parametrize("test_data", INPUT_VXLAN_STATUS, ids=generate_test_ids_list(INPUT_VXLAN_STATUS))
@@ -26,6 +26,22 @@ def test_VerifyVxlan(mocked_device: MagicMock, test_data: Any) -> None:
     logging.info(f"Mocked HW is: {mocked_device.hw_model}")
 
     test = VerifyVxlan(mocked_device, eos_data=test_data["eos_data"])
+    asyncio.run(test.test())
+    logging.info(f"test result is: {test.result}")
+
+    assert str(test.result.name) == mocked_device.name
+    assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
+
+
+@pytest.mark.parametrize("test_data", INPUT_VXLAN_CONFIG_SANITY, ids=generate_test_ids_list(INPUT_VXLAN_CONFIG_SANITY))
+def test_VerifyVxlanConfigSanity(mocked_device: MagicMock, test_data: Any) -> None:
+    """Check VerifyVxlan"""
+
+    logging.info(f"Mocked device is: {mocked_device.host}")
+    logging.info(f"Mocked HW is: {mocked_device.hw_model}")
+
+    test = VerifyVxlanConfigSanity(mocked_device, eos_data=test_data["eos_data"])
     asyncio.run(test.test())
     logging.info(f"test result is: {test.result}")
 

--- a/tests/units/anta_tests/vxlan/test_exc.py
+++ b/tests/units/anta_tests/vxlan/test_exc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Tests for anta.tests.mlag.py
+Tests for anta.tests.vxlan.py
 """
 from __future__ import annotations
 


### PR DESCRIPTION
# Changes to test cases
I made two adjustments to the test cases, as this seemed appropriate
1. If the `Vxlan1` interface can't be found, we mark it as a [`skip`](https://github.com/colinmacgiolla/network_tests_automation/blob/d170dcab3e7a66dd9a08eb22800bc1e17e81d92e/anta/tests/vxlan.py#L30) rather than a [`fail`](https://github.com/colinmacgiolla/network_tests_automation/blob/601962884e0284da22d7202cb300ba7d36ad9345/anta/tests/vxlan.py#L35)
2. I added the `platform_dependent` category to our [pass/fail set](https://github.com/colinmacgiolla/network_tests_automation/blob/d170dcab3e7a66dd9a08eb22800bc1e17e81d92e/anta/tests/vxlan.py#L63) since that seemed useful for older R/R2 series systems

# Checklist
- [x] Change to new syntax for VXLAN related tests
- [x] Add pytest cases for each of the VXLAN tests
