### PR TITLE
feat(anta): Implement Result manager for Jinja2 rendering

### DIFF
--- a/anta/cli/check/commands.py
+++ b/anta/cli/check/commands.py
@@ -139,11 +139,13 @@ def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: b
 @click.pass_context
 @click.option("--catalog", "-c", show_envvar=True, prompt="Path for tests catalog", help="Path for tests catalog", type=click.Path(), required=True)
 @click.option("--template", "-tpl", type=click.Path(), required=True, help="Path to the template to use for your report")
+@click.option("--output", "-o", type=click.Path(), default=None, required=False, help="Path to use to save report")
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
 @click.option(
     "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
 )
-def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_level: str) -> bool:
+def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_level: str, output: str) -> bool:
+    # pylint: disable=too-many-arguments
     """ANTA command to check network state with templated report"""
     console = Console()
     inventory = ctx.obj["inventory"]
@@ -174,6 +176,6 @@ def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_l
         )
     )
 
-    display_jinja(console=console, results=results, template=template)
+    display_jinja(console=console, results=results, template=template, output=output)
 
     return True

--- a/anta/cli/check/commands.py
+++ b/anta/cli/check/commands.py
@@ -14,7 +14,7 @@ from rich.theme import Theme
 
 from anta import RICH_COLOR_THEME
 
-from .utils import check_run, display_json, display_table
+from .utils import check_run, display_jinja, display_json, display_table
 
 logger = logging.getLogger(__name__)
 
@@ -132,4 +132,48 @@ def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: b
         if any(regexp.match(entry) for entry in [line.name, line.test]) and (not skip_error or line.result != "error"):
             message = f" ({str(line.messages[0])})" if len(line.messages) > 0 else ""
             console.print(f"{line.name} :: {line.test} :: [{line.result}]{line.result.upper()}[/{line.result}]{message}", highlight=False)
+    return True
+
+
+@click.command()
+@click.pass_context
+@click.option("--catalog", "-c", show_envvar=True, prompt="Path for tests catalog", help="Path for tests catalog", type=click.Path(), required=True)
+@click.option("--template", "-tpl", type=click.Path(), required=True, help="Path to the template to use for your report")
+@click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
+@click.option(
+    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
+)
+def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_level: str) -> bool:
+    """ANTA command to check network state with templated report"""
+    console = Console()
+    inventory = ctx.obj["inventory"]
+
+    results = check_run(
+        inventory=inventory,
+        catalog=catalog,
+        username=ctx.obj["username"],
+        password=ctx.obj["password"],
+        timeout=ctx.obj["timeout"],
+        enable_password=ctx.obj["enable_password"],
+        tags=tags,
+        loglevel=log_level,
+    )
+
+    if log_level.upper() == "DEBUG":
+        console.print(Panel.fit("List results of all tests", style="red"))
+        console.print(results.get_results(output_format="json"))
+
+    console.print(
+        Panel.fit(
+            f"Running check-devices with:\n\
+              - Inventory: {inventory}\n\
+              - Tests catalog: {catalog}\n\
+              - Template: {template}",
+            style="cyan",
+            title="[green]Settings",
+        )
+    )
+
+    display_jinja(console=console, results=results, template=template)
+
     return True

--- a/anta/cli/check/utils.py
+++ b/anta/cli/check/utils.py
@@ -8,7 +8,7 @@ Utils functions to use with anta.cli.check.commands module.
 import asyncio
 import json
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from rich import print_json
 from rich.console import Console
@@ -83,9 +83,13 @@ def display_list(console: Console, results: ResultManager, output_file: Optional
             fout.write(str(results.get_results(output_format="list")))
 
 
-def display_jinja(console: Console, results: ResultManager, template: str) -> None:
+def display_jinja(console: Console, results: ResultManager, template: str, output: Union[str, None] = None) -> None:
     """Display result based on template."""
     # console.print(Panel.fit(f"Custom report from {template}", style="cyan"))
     reporter = ReportJinja(template_path=template)
     json_data = json.loads(results.get_results(output_format="json"))
-    console.print(reporter.render(json_data))
+    report = reporter.render(json_data)
+    console.print(report)
+    if output is not None:
+        with open(output, "w", encoding="utf-8") as file:
+            file.write(report)

--- a/anta/cli/check/utils.py
+++ b/anta/cli/check/utils.py
@@ -6,6 +6,7 @@ Utils functions to use with anta.cli.check.commands module.
 """
 
 import asyncio
+import json
 import logging
 from typing import Any, Optional
 
@@ -18,7 +19,7 @@ from yaml import safe_load
 from anta.cli.utils import setup_logging
 from anta.inventory import AntaInventory
 from anta.loader import parse_catalog
-from anta.reporter import ReportTable
+from anta.reporter import ReportJinja, ReportTable
 from anta.result_manager import ResultManager
 from anta.runner import main
 
@@ -80,3 +81,11 @@ def display_list(console: Console, results: ResultManager, output_file: Optional
     if output_file is not None:
         with open(output_file, "w", encoding="utf-8") as fout:
             fout.write(str(results.get_results(output_format="list")))
+
+
+def display_jinja(console: Console, results: ResultManager, template: str) -> None:
+    """Display result based on template."""
+    # console.print(Panel.fit(f"Custom report from {template}", style="cyan"))
+    reporter = ReportJinja(template_path=template)
+    json_data = json.loads(results.get_results(output_format="json"))
+    console.print(reporter.render(json_data))

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -82,6 +82,7 @@ def cli() -> None:
     nrfu.add_command(check_commands.table)
     nrfu.add_command(check_commands.json)
     nrfu.add_command(check_commands.text)
+    nrfu.add_command(check_commands.tpl_report)
     # Load CLI
     anta(obj={}, auto_envvar_prefix="ANTA")
 

--- a/anta/reporter/__init__.py
+++ b/anta/reporter/__init__.py
@@ -232,12 +232,17 @@ class ReportJinja:
 
         Report is built based on a J2 template provided by user.
         Data structure sent to template is:
-        data = [
+
+        >>> data = ResultManager.get_results(output_format="json")
+        >>> print(data)
+        [
             {
                 name: ...,
                 test: ...,
                 result: ...,
                 messages: [...]
+                test_category: ...,
+                test_description: ...,
             }
         ]
 

--- a/anta/reporter/__init__.py
+++ b/anta/reporter/__init__.py
@@ -2,9 +2,13 @@
 Report management for ANTA.
 """
 
-import logging
-from typing import Any, List, Optional
+# pylint: disable = too-few-public-methods
 
+import logging
+import os.path
+from typing import Any, Dict, List, Optional
+
+from jinja2 import Template
 from rich.table import Table
 
 from anta import RICH_COLOR_PALETTE
@@ -211,3 +215,41 @@ class ReportTable:
                     str(list_failure),
                 )
         return table
+
+
+class ReportJinja:
+    """Report builder based on a Jinja2 template."""
+
+    def __init__(self, template_path: str) -> None:
+        if os.path.isfile(template_path):
+            self.tempalte_path = template_path
+        else:
+            raise FileNotFoundError(f"template file is not found: {template_path}")
+
+    def render(self, data: List[Dict[str, Any]], trim_blocks: bool = True, lstrip_blocks: bool = True) -> str:
+        """
+        Build a report based on a Jinja2 template
+
+        Report is built based on a J2 template provided by user.
+        Data structure sent to template is:
+        data = [
+            {
+                name: ...,
+                test: ...,
+                result: ...,
+                messages: [...]
+            }
+        ]
+
+        Args:
+            data (List[Dict[str, Any]]): List of results from ResultManager.get_results
+            trim_blocks (bool, optional): enable trim_blocks for J2 rendering. Defaults to True.
+            lstrip_blocks (bool, optional): enable lstrip_blocks for J2 rendering. Defaults to True.
+
+        Returns:
+            str: rendered template
+        """
+        with open(self.tempalte_path, encoding="utf-8") as file_:
+            template = Template(file_.read(), trim_blocks=trim_blocks, lstrip_blocks=lstrip_blocks)
+
+        return template.render({"data": data})

--- a/anta/result_manager/__init__.py
+++ b/anta/result_manager/__init__.py
@@ -87,7 +87,7 @@ class ResultManager:
         Args:
             entries (List[TestResult]): list of TestResult data to add to the report
         """
-        logger.info(f"add new list of results to manager: {[r.result for r in entries]}")
+        logger.info(f"add new list of results to manager: {[r.result for r in entries if r is not None]}")
         self._result_entries.extend(entries)
 
     def get_results(self, output_format: str = "native") -> Any:

--- a/docs/cli/nrfu.md
+++ b/docs/cli/nrfu.md
@@ -5,6 +5,7 @@ All the NRFU testing commands are placed under `anta nrfu` and provide different
 - Table view
 - JSON view
 - Text view
+- Custom template view
 
 ```bash
 anta nrfu
@@ -16,9 +17,10 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  json   ANTA command to check network state with JSON result
-  table  ANTA command to check network states with table result
-  text   ANTA command to check network states with text result
+  json        ANTA command to check network state with JSON result
+  table       ANTA command to check network states with table result
+  text        ANTA command to check network states with text result
+  tpl-report  ANTA command to check network state with templated report
 ```
 
 All of these commands require the following input:
@@ -79,17 +81,25 @@ This command is helpful to generate a JSON and then pass it to another tool for 
 $ anta check json -t pod1 -c nrfu/leaf.yml
 [
   {
-    "name": "leaf2",
-    "test": "VerifyMlagStatus",
+    "name": "leaf01",
+    "test": "verify_zerotouch",
+    "test_category": [
+      "configuration"
+    ],
+    "test_description": "Verifies ZeroTouch is disabled.",
     "result": "success",
-    "messages": "[]"
+    "messages": []
   },
   {
-    "name": "leaf2",
-    "test": "VerifyMlagInterface",
+    "name": "leaf01",
+    "test": "verify_running_config_diffs",
+    "test_category": [
+      "configuration"
+    ],
+    "test_description": "",
     "result": "success",
-    "messages": "[]"
-  }
+    "messages": []
+  },
 ]
 ```
 

--- a/docs/cli/nrfu.md
+++ b/docs/cli/nrfu.md
@@ -92,3 +92,53 @@ $ anta check json -t pod1 -c nrfu/leaf.yml
   }
 ]
 ```
+
+## NRFU with your own report
+
+Because you may want to have a specific report format, ANTA provides a CLI option to build report based on Jinja2 template.
+
+```bash
+$ anta nrfu tpl-report -c .personal/catalog-class.yml -tpl .personal/test_template.j2
+╭───────────────────────── Settings ─────────────────────────╮
+│ Running check-devices with:                                │
+│               - Inventory: .personal/inventory_atd.yml     │
+│               - Tests catalog: .personal/catalog-class.yml │
+│               - Template: .personal/test_template.j2       │
+╰────────────────────────────────────────────────────────────╯
+* verify_zerotouch is SUCCESS for spine01
+* verify_running_config_diffs is SUCCESS for spine01
+* verify_interface_utilization is SUCCESS for spine01
+```
+
+And the template `.personal/test_template.j2` is a pure Jinja2 template:
+
+```j2
+$ cat .personal/test_template.j2
+{% for d in data %}
+* {{ d.test }} is [green]{{ d.result | upper}}[/green] for {{ d.name }}
+{% endfor %}
+```
+
+In this context, Jinja2 template can access to all `TestResult` elements with their values as described in [this documentation](../api/result_manager_models.md#testresult-entry).
+
+An option is available to save the generated report into a text file:
+
+```bash
+# Run ANTA
+$ anta nrfu tpl-report -c .personal/catalog-class.yml -tpl .personal/test_template.j2 -o .personal/demo.txt
+╭───────────────────────── Settings ─────────────────────────╮
+│ Running check-devices with:                                │
+│               - Inventory: .personal/inventory_atd.yml     │
+│               - Tests catalog: .personal/catalog-class.yml │
+│               - Template: .personal/test_template.j2       │
+╰────────────────────────────────────────────────────────────╯
+* verify_zerotouch is SUCCESS for spine01
+* verify_running_config_diffs is SUCCESS for spine01
+* verify_interface_utilization is SUCCESS for spine01
+
+# Display saved report
+$ cat .personal/demo.txt
+* verify_zerotouch is [green]SUCCESS[/green] for spine01
+* verify_running_config_diffs is [green]SUCCESS[/green] for spine01
+* verify_interface_utilization is [green]SUCCESS[/green] for spine01
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "rich>=12.5.1",
   "scp",
   "asyncssh==2.13.1",
+  "Jinja2>=3.1.2",
 ]
 keywords = ["test", "anta", "Arista", "network", "automation", "networking", "devops", "netdevops"]
 classifiers = [


### PR DESCRIPTION
Implement option to render result using jinja2 template so it can be fully customised by the user.

## Usage example

```bash
anta nrfu tpl-report -c .personal/catalog-class.yml -tpl .personal/test_template.j2 -o .personal/demo.txt
╭───────────────────────── Settings ─────────────────────────╮
│ Running check-devices with:                                │
│               - Inventory: .personal/inventory_atd.yml     │
│               - Tests catalog: .personal/catalog-class.yml │
│               - Template: .personal/test_template.j2       │
╰────────────────────────────────────────────────────────────╯
* verify_zerotouch is SUCCESS for spine01
* verify_running_config_diffs is SUCCESS for spine01
* verify_interface_utilization is SUCCESS for spine01

❯ cat .personal/demo.txt
* verify_zerotouch is [green]SUCCESS[/green] for spine01
* verify_running_config_diffs is [green]SUCCESS[/green] for spine01
* verify_interface_utilization is [green]SUCCESS[/green] for spine01
```

## Template example

```j2
{% for d in data %}
* {{ d.test }} is [green]{{ d.result | upper}}[/green] for {{ d.name }}
{% endfor %}
```

## Todo

- [x] Add option to save report
- [x] Build documentation to use with CLI