### PR TITLE
fix(anta.cli): Update exec snapshot to support no enable-password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ venv.bak/
 test.env
 tech-support/
 tech-support/*
+2*
 
 **/report.html
 .*report.html

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -66,10 +66,16 @@ async def collect_commands(
             outdir = Path() / root_dir / dev.name / outformat
             outdir.mkdir(parents=True, exist_ok=True)
             outfile = outdir / command
-            result = await dev.session.cli(
-                commands=[{"cmd": "enable", "input": enable_pass}, command],
-                ofmt=outformat,
-            )
+            if enable_pass is not None:
+                result = await dev.session.cli(
+                    commands=[{"cmd": "enable", "input": enable_pass}, command],
+                    ofmt=outformat,
+                )
+            else:
+                result = await dev.session.cli(
+                    commands=["", command],
+                    ofmt=outformat,
+                )
             with outfile.open(mode="w", encoding="UTF-8") as f:
                 f.write(str(result[1]))
             logger.info(f"Collected command '{command}' from device {dev.name} ({dev.hw_model})")

--- a/anta/result_manager/models.py
+++ b/anta/result_manager/models.py
@@ -23,6 +23,7 @@ class TestResult(BaseModel):
     result: str = "unset"
     messages: List[str] = []
 
+    @classmethod
     @validator("result", allow_reuse=True)
     def name_must_be_in(cls, v: str) -> str:
         """


### PR DESCRIPTION
Remove sending `{"cmd": "enable", "input": enable_pass}` if enable_password is not required in user's setup.

Fixes #208 