### PR TITLE
feat(anta): Enable support for AntaTestTemplate

### DIFF
--- a/anta/cli/check/commands.py
+++ b/anta/cli/check/commands.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.theme import Theme
 
 from anta import RICH_COLOR_THEME
+from anta.cli.utils import setup_logging
 
 from .utils import check_run, display_json, display_table
 
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: str, log_level: str) -> bool:
     """ANTA command to check network states with table result"""
     # pylint: disable=too-many-arguments
+    setup_logging(level=log_level)
     console = Console()
     inventory = ctx.obj["inventory"]
 
@@ -76,6 +78,7 @@ def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: st
 )
 def json(ctx: click.Context, catalog: str, output: str, tags: str, log_level: str) -> bool:
     """ANTA command to check network state with JSON result"""
+    setup_logging(level=log_level)
     console = Console()
     inventory = ctx.obj["inventory"]
 
@@ -115,6 +118,7 @@ def json(ctx: click.Context, catalog: str, output: str, tags: str, log_level: st
 def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: bool, log_level: str) -> bool:
     """ANTA command to check network states with text result"""
     # pylint: disable=too-many-arguments
+    setup_logging(level=log_level)
     custom_theme = Theme(RICH_COLOR_THEME)
     console = Console(theme=custom_theme)
     results = check_run(

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -28,23 +28,29 @@ def setup_logging(level: str = "info") -> None:
         level (str, optional): level name to configure. Defaults to 'critical'.
     """
     loglevel = getattr(logging, level.upper())
-    logging.getLogger("anta").setLevel(loglevel)
     logging.getLogger("aioeapi").setLevel(loglevel)
 
+    # Logging for anta framework
+    logging.getLogger("anta").setLevel(loglevel)
     logging.getLogger("anta.inventory").setLevel(loglevel)
     logging.getLogger("anta.result_manager").setLevel(loglevel)
     logging.getLogger("anta.reporter").setLevel(loglevel)
     logging.getLogger("anta.runner").setLevel(loglevel)
 
+    # Logging for anta.tests.*
     logging.getLogger("anta.tests").setLevel(logging.ERROR)
+    logging.getLogger("anta.tests.aaa").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.configuration").setLevel(logging.ERROR)
+    logging.getLogger("anta.tests.field_notices").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.hardware").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.interfaces").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.mlag").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.multicast").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.profiles").setLevel(logging.ERROR)
-    logging.getLogger("anta.tests.system").setLevel(logging.ERROR)
+    logging.getLogger("anta.tests.security").setLevel(logging.ERROR)
+    logging.getLogger("anta.tests.snmp").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.software").setLevel(logging.ERROR)
+    logging.getLogger("anta.tests.system").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.vxlan").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.routing.generic").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.routing.bgp").setLevel(logging.ERROR)

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -33,8 +33,9 @@ def setup_logging(level: str = "info") -> None:
 
     logging.getLogger("anta.inventory").setLevel(loglevel)
     logging.getLogger("anta.result_manager").setLevel(loglevel)
+    logging.getLogger("anta.reporter").setLevel(loglevel)
+    logging.getLogger("anta.runner").setLevel(loglevel)
 
-    logging.getLogger("anta.reporter").setLevel(logging.CRITICAL)
     logging.getLogger("anta.tests").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.configuration").setLevel(logging.ERROR)
     logging.getLogger("anta.tests.hardware").setLevel(logging.ERROR)

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -14,7 +14,7 @@ from anta.result_manager.models import TestResult
 logger = logging.getLogger(__name__)
 
 # Key from YAML file tranfered to AntaTestTemplate of the test.
-TEST_TPL_PARAM = "tpl_options"
+TEST_TPL_PARAMS = "tpl_options"
 
 
 async def main(
@@ -34,12 +34,11 @@ async def main(
         tests (List[...]): Test catalog. Output of anta.loader.parse_catalog().
 
     Example:
-        anta.tests.aaa:
-          - VerifyAAAMethods:
-              method: login
-              tpl_options:
-                - stage: authentication
-                - stage: authorization
+        anta.tests.routing.bgp:
+        - VerifyBGPIPv4UnicastCount:
+            number: 3
+            tpl_options:
+                - vrf: default
 
     Returns:
         any: List of results.
@@ -51,7 +50,9 @@ async def main(
 
     res = await asyncio.gather(
         *(
-            test[0](device=device, template_params=test[1].get(TEST_TPL_PARAM, [])).test(eos_data=None, **{k: v for k, v in test[1].items() if k != TEST_TPL_PARAM})
+            test[0](device=device, template_params=test[1].get(TEST_TPL_PARAMS, [])).test(
+                eos_data=None, **{k: v for k, v in test[1].items() if k != TEST_TPL_PARAMS}
+            )
             for device, test in itertools.product(inventory.get_inventory(established_only=established_only, tags=tags), tests)
         ),
         return_exceptions=True,

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -14,7 +14,7 @@ from anta.result_manager.models import TestResult
 logger = logging.getLogger(__name__)
 
 # Key from YAML file tranfered to AntaTestTemplate of the test.
-TEST_TPL_PARAMS = "tpl_options"
+TEST_TPL_PARAMS = "template_params"
 
 
 async def main(

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -51,16 +51,8 @@ async def main(
 
     res = await asyncio.gather(
         *(
-            test[0](device=device,
-                    template_params=test[1].get(TEST_TPL_PARAM, [])
-                    ).test(
-                eos_data=None,
-                **{k: v for k, v in test[1].items() if k != TEST_TPL_PARAM}
-            )
-            for device, test in itertools.product(
-                inventory.get_inventory(established_only=established_only, tags=tags),
-                tests
-            )
+            test[0](device=device, template_params=test[1].get(TEST_TPL_PARAM, [])).test(eos_data=None, **{k: v for k, v in test[1].items() if k != TEST_TPL_PARAM})
+            for device, test in itertools.product(inventory.get_inventory(established_only=established_only, tags=tags), tests)
         ),
         return_exceptions=True,
     )

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -37,7 +37,7 @@ async def main(
         anta.tests.routing.bgp:
         - VerifyBGPIPv4UnicastCount:
             number: 3
-            tpl_options:
+            template_params:
                 - vrf: default
 
     Returns:

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -99,6 +99,36 @@ anta.tests.configuration:
   - VerifyRunningConfigDiffs:
 ```
 
+If your test is based on [`AntaTestTemplate`](), you have to provide inputs for EOS CLI template by using `tpl_options` list:
+
+```yaml
+anta.tests.routing.bgp:
+  - VerifyBGPIPv4UnicastCount:
+      number: 3
+      tpl_options:
+        - vrf: default
+        - vrf: customer-01
+```
+
+Which is required for the following test definition:
+
+```python
+class VerifyBGPIPv4UnicastCount(AntaTest):
+    """
+    ...
+    """
+
+    name = "VerifyBGPIPv4UnicastCount"
+    description = "..."
+    categories = ["routing", "bgp"]
+    template = AntaTestTemplate(template="show bgp ipv4 unicast summary vrf {vrf}")
+
+    @check_bgp_family_enable("ipv4")
+    @AntaTest.anta_test
+    def test(self, number: Optional[int] = None) -> None:
+        pass
+```
+
 ### Custom tests catalog
 
 In case you want to leverage your own tests collection, you can use the following syntax:

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -105,7 +105,7 @@ If your test is based on [`AntaTestTemplate`](), you have to provide inputs for 
 anta.tests.routing.bgp:
   - VerifyBGPIPv4UnicastCount:
       number: 3
-      tpl_options:
+      template_params:
         - vrf: default
         - vrf: customer-01
 ```


### PR DESCRIPTION
Fixes #212 

Changes:

- feat(anta): Enable support for AntaTestTemplate
- fix(anta.cli): propagate setup_logging to all nrfu CLI

New Catalog option for AntaTestTemplate based test

```yml
anta.tests.routing.bgp:
  - VerifyBGPIPv4UnicastCount:
      number: 3 
      tpl_options:
        - vrf: default
```
