### PR TITLE
fix(anta): fix logging

### DIFF
--- a/anta/models.py
+++ b/anta/models.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+logger = logging.getLogger(__name__)
+
 
 class AntaTestTemplate(BaseModel):
     """Class to define a test command with its API version
@@ -119,8 +121,6 @@ class AntaTest(ABC):
         labels: list[str] | None = None,
     ):
         """Class constructor"""
-        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
-        self.logger.setLevel(level="INFO")
         self.device = device
         self.result = TestResult(name=device.name, test=self.name, test_category=self.categories, test_description=self.description)
         self.labels = labels or []
@@ -147,7 +147,7 @@ class AntaTest(ABC):
             )
 
         if eos_data is not None:
-            self.logger.debug("Test initialized with input data")
+            logger.debug("Test initialized with input data")
             self.save_commands_data(eos_data)
 
     def save_commands_data(self, eos_data: list[dict[Any, Any] | str]) -> None:
@@ -210,7 +210,7 @@ class AntaTest(ABC):
 
             # Data
             if eos_data is not None:
-                self.logger.debug("Test initialized with input data")
+                logger.debug("Test initialized with input data")
                 self.save_commands_data(eos_data)
 
             # No test data is present, try to collect
@@ -219,14 +219,14 @@ class AntaTest(ABC):
                 if self.result.result != "unset":
                     return self.result
 
-            self.logger.debug(f"Running asserts for test {self.name} for device {self.device.name}: running collect")
+            logger.debug(f"Running asserts for test {self.name} for device {self.device.name}: running collect")
             try:
                 if not self.all_data_collected():
                     raise ValueError("Some command output is missing")
                 function(self, **kwargs)
             except Exception as e:  # pylint: disable=broad-exception-caught
-                self.logger.error(f"Exception raised during 'assert' for test {self.name} (on device {self.device.name}) - {exc_to_str(e)}")
-                self.logger.debug(traceback.format_exc())
+                logger.error(f"Exception raised during 'assert' for test {self.name} (on device {self.device.name}) - {exc_to_str(e)}")
+                logger.debug(traceback.format_exc())
                 self.result.is_error(exc_to_str(e))
             return self.result
 

--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -67,9 +67,9 @@ class VerifyTacacsSourceIntf(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because intf or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         try:
             if command_output["srcIntf"][vrf] == intf:
@@ -109,9 +109,9 @@ class VerifyTacacsServers(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because servers or vrf were not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         tacacs_servers = command_output["tacacsServers"]
 
@@ -158,9 +158,9 @@ class VerifyTacacsServerGroups(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because groups were not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         tacacs_groups = command_output["groups"]
 
@@ -208,9 +208,9 @@ class VerifyAuthenMethods(AntaTest):
 
         _check_auth_type(auth_types, ["login", "enable", "dot1x"])
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         not_matching = []
 
@@ -267,9 +267,9 @@ class VerifyAuthzMethods(AntaTest):
 
         methods_with_group = _check_group_methods(methods)
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         not_matching = []
 
@@ -319,9 +319,9 @@ class VerifyAcctDefaultMethods(AntaTest):
 
         _check_auth_type(auth_types, ["system", "exec", "commands", "dot1x"])
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         not_matching = []
         not_configured = []
@@ -379,9 +379,9 @@ class VerifyAcctConsoleMethods(AntaTest):
 
         _check_auth_type(auth_types, ["system", "exec", "commands", "dot1x"])
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         not_matching = []
         not_configured = []

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -26,9 +26,9 @@ class VerifyZeroTouch(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyZeroTouch validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = self.instance_commands[0].output
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
         assert isinstance(command_output, dict)
         if command_output["mode"] == "disabled":
             self.result.is_success()
@@ -49,12 +49,12 @@ class VerifyRunningConfigDiffs(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyRunningConfigDiffs validation"""
-        self.logger.debug(f"self.instance_commands is {self.instance_commands}")
+        logger.debug(f"self.instance_commands is {self.instance_commands}")
         command_output = self.instance_commands[0].output
-        self.logger.debug(f"command_output is {command_output}")
+        logger.debug(f"command_output is {command_output}")
         if command_output is None or command_output == "":
             self.result.is_success()
         else:
             self.result.is_failure()
             self.result.is_failure(str(command_output))
-        self.logger.debug(f"result is {self.result}")
+        logger.debug(f"result is {self.result}")

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -1,13 +1,14 @@
 """
 Test functions related to the device interfaces
 """
+import logging
 import re
 from typing import Any, Dict, List, cast
 
 from anta.decorators import skip_on_platforms
 from anta.models import AntaTest, AntaTestCommand
 
-# pylint: disable=W0511
+logger = logging.getLogger(__name__)
 
 
 class VerifyInterfaceUtilization(AntaTest):
@@ -24,9 +25,9 @@ class VerifyInterfaceUtilization(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyInterfaceUtilization validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         wrong_interfaces = {}
         for line in command_output.split("\n")[1:]:
@@ -57,9 +58,9 @@ class VerifyInterfaceErrors(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyInterfaceUtilization validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         wrong_interfaces: List[Dict[str, Dict[str, int]]] = []
         for interface, outer_v in command_output["interfaceErrorCounters"].items():

--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -36,11 +36,11 @@ class VerifyLoggingPersistent(AntaTest):
         """
         Run VerifyLoggingPersistent validation.
         """
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         log_output = cast(str, self.instance_commands[0].output)
         dir_flash_output = cast(str, self.instance_commands[1].output)
-        self.logger.debug(f"dataset of log_output command is: {log_output}")
-        self.logger.debug(f"dataset of dir_flash_output command is: {dir_flash_output}")
+        logger.debug(f"dataset of log_output command is: {log_output}")
+        logger.debug(f"dataset of dir_flash_output command is: {dir_flash_output}")
 
         pattern = r"-rw-\s+(\d+)"
         match = re.search(pattern, dir_flash_output)
@@ -83,9 +83,9 @@ class VerifyLoggingSourceIntf(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because intf or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         pattern = rf"Logging source-interface '{intf}'.*VRF {vrf}"
 
@@ -123,9 +123,9 @@ class VerifyLoggingHosts(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because hosts or vrf were not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         not_configured = []
 
@@ -163,9 +163,9 @@ class VerifyLoggingLogsGeneration(AntaTest):
         Run VerifyLoggingLogs validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[1].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         log_pattern = r"ANTA VerifyLoggingLogsGeneration validation"
 
@@ -203,11 +203,11 @@ class VerifyLoggingHostname(AntaTest):
         Run VerifyLoggingHostname validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         hostname_output = cast(Dict[str, str], self.instance_commands[0].output)
         log_output = cast(str, self.instance_commands[2].output)
-        self.logger.debug(f"dataset of hostname_output is: {hostname_output}")
-        self.logger.debug(f"dataset of log_output is: {log_output}")
+        logger.debug(f"dataset of hostname_output is: {hostname_output}")
+        logger.debug(f"dataset of log_output is: {log_output}")
 
         fqdn = hostname_output["fqdn"]
 
@@ -250,9 +250,9 @@ class VerifyLoggingTimestamp(AntaTest):
         Run VerifyLoggingTimestamp validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[1].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         log_pattern = r"ANTA VerifyLoggingTimestamp validation"
         timestamp_pattern = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}-\d{2}:\d{2}"
@@ -291,9 +291,9 @@ class VerifyLoggingAccounting(AntaTest):
         Run VerifyLoggingAccountingvalidation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         pattern = r"cmd=show aaa accounting logs"
 

--- a/anta/tests/mlag.py
+++ b/anta/tests/mlag.py
@@ -23,9 +23,9 @@ class VerifyMlagStatus(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyMlagStatus validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if command_output["state"] == "disabled":
             self.result.is_skipped("MLAG is disabled")
@@ -53,9 +53,9 @@ class VerifyMlagInterfaces(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyMlagInterfaces validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if command_output["state"] == "disabled":
             self.result.is_skipped("MLAG is disabled")
@@ -78,9 +78,9 @@ class VerifyMlagConfigSanity(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyMlagConfigSanity validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if "mlagActive" not in command_output.keys():
             self.result.is_error("Incorrect JSON response - mlagActive state not found")

--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -31,9 +31,9 @@ class VerifySSHStatus(AntaTest):
         Run VerifySSHStatus validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(str, self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         line = [line for line in command_output.split("\n") if line.startswith("SSHD status")][0]
         status = line.split("is ")[1]
@@ -72,9 +72,9 @@ class VerifySSHIPv4Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv4_acl_list = command_output["ipAclList"]["aclList"]
         ipv4_acl_number = len(ipv4_acl_list)
@@ -122,9 +122,9 @@ class VerifySSHIPv6Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv6_acl_list = command_output["ipv6AclList"]["aclList"]
         ipv6_acl_number = len(ipv6_acl_list)
@@ -164,9 +164,9 @@ class VerifyTelnetStatus(AntaTest):
         Run VerifyTelnetStatus validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if command_output["serverState"] == "disabled":
             self.result.is_success()
@@ -194,9 +194,9 @@ class VerifyAPIHttpStatus(AntaTest):
         Run VerifyAPIHTTPStatus validation.
         """
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if command_output["enabled"] and not command_output["httpServer"]["running"]:
             self.result.is_success()
@@ -231,9 +231,9 @@ class VerifyAPIHttpsSSL(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because profile was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Any], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         try:
             if command_output["sslProfile"]["name"] == profile and command_output["sslProfile"]["state"] == "valid":
@@ -273,9 +273,9 @@ class VerifyAPIIPv4Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv4_acl_list = command_output["ipAclList"]["aclList"]
         ipv4_acl_number = len(ipv4_acl_list)
@@ -323,9 +323,9 @@ class VerifyAPIIPv6Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv6_acl_list = command_output["ipv6AclList"]["aclList"]
         ipv6_acl_number = len(ipv6_acl_list)

--- a/anta/tests/snmp.py
+++ b/anta/tests/snmp.py
@@ -37,9 +37,9 @@ class VerifySnmpStatus(AntaTest):
         if not vrf:
             self.result.is_skipped(f"{self.__class__.name} did not run because vrf was not supplied")
         else:
-            self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+            logger.debug(f"self.instance_commands is: {self.instance_commands}")
             command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-            self.logger.debug(f"dataset is: {command_output}")
+            logger.debug(f"dataset is: {command_output}")
 
             if command_output["enabled"] and vrf in command_output["vrfs"]["snmpVrfs"]:
                 self.result.is_success()
@@ -75,9 +75,9 @@ class VerifySnmpIPv4Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv4_acl_list = command_output["ipAclList"]["aclList"]
         ipv4_acl_number = len(ipv4_acl_list)
@@ -125,9 +125,9 @@ class VerifySnmpIPv6Acl(AntaTest):
             self.result.is_skipped(f"{self.__class__.name} did not run because number or vrf was not supplied")
             return
 
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         ipv6_acl_list = command_output["ipv6AclList"]["aclList"]
         ipv6_acl_number = len(ipv6_acl_list)

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -22,9 +22,9 @@ class VerifyVxlan(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyVxlan validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         if "Vxlan1" not in command_output["interfaceDescriptions"]:
             self.result.is_skipped("Vxlan1 interface is not configured")
@@ -53,9 +53,9 @@ class VerifyVxlanConfigSanity(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Run VerifyVxlanConfigSanity validation"""
-        self.logger.debug(f"self.instance_commands is: {self.instance_commands}")
+        logger.debug(f"self.instance_commands is: {self.instance_commands}")
         command_output = cast(Dict[str, Dict[str, Any]], self.instance_commands[0].output)
-        self.logger.debug(f"dataset is: {command_output}")
+        logger.debug(f"dataset is: {command_output}")
 
         failed_categories = {
             category: content


### PR DESCRIPTION
Removed `self.logger` in `AntaTest` class as per the Python recommendation: https://docs.python.org/3/library/logging.html#logger-objects
The logger name hierarchy is analogous to the Python package hierarchy, and identical to it if you organise your loggers on a per-module basis using the recommended construction logging.getLogger(__name__). That’s because in a module, __name__ is the module’s name in the Python package namespace.

This would also avoid having things logged as `anta.models` when the actual code is somewhere in `anta.tests`.

I also removed the static `setLevel` calls. I did not get how I am supposed to change the logging level with the `--log-level` CLI option if some modules are always using `ERROR` or `CRITICAL`
