### PR TITLE
refactor(anta): Refactor AntaDevice and CLI scripts

### DIFF
--- a/anta/cli/check/commands.py
+++ b/anta/cli/check/commands.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--group-by", default=None, type=click.Choice(["none", "host", "test"], case_sensitive=False), help="Group result by test or host. default none", required=False
 )
-def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: str) -> bool:
+def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: str) -> None:
     """ANTA command to check network states with table result"""
     # pylint: disable=too-many-arguments
     console = Console()
@@ -44,18 +44,8 @@ def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: st
         )
     )
 
-    results = check_run(
-        inventory=inventory,
-        catalog=catalog,
-        username=ctx.obj["username"],
-        password=ctx.obj["password"],
-        timeout=ctx.obj["timeout"],
-        enable_password=ctx.obj["enable_password"],
-        tags=tags,
-    )
+    results = check_run(inventory=inventory, catalog=catalog, tags=tags)
     display_table(console=console, results=results, group_by=group_by, search=search)
-
-    return True
 
 
 @click.command()
@@ -64,7 +54,7 @@ def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: st
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
 # Options valid with --display json
 @click.option("--output", "-o", default=None, help="Path to save output in json or list", type=click.File(), required=False)
-def json(ctx: click.Context, catalog: str, output: str, tags: str) -> bool:
+def json(ctx: click.Context, catalog: str, output: str, tags: str) -> None:
     """ANTA command to check network state with JSON result"""
     console = Console()
     inventory = ctx.obj["inventory"]
@@ -78,18 +68,8 @@ def json(ctx: click.Context, catalog: str, output: str, tags: str) -> bool:
         )
     )
 
-    results = check_run(
-        inventory=inventory,
-        catalog=catalog,
-        username=ctx.obj["username"],
-        password=ctx.obj["password"],
-        timeout=ctx.obj["timeout"],
-        enable_password=ctx.obj["enable_password"],
-        tags=tags,
-    )
+    results = check_run(inventory=inventory, catalog=catalog, tags=tags)
     display_json(console=console, results=results, output_file=output)
-
-    return True
 
 
 @click.command()
@@ -98,26 +78,17 @@ def json(ctx: click.Context, catalog: str, output: str, tags: str) -> bool:
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
 @click.option("--search", "-s", default=".*", help="Regular expression to search in both name and test", type=str, required=False)
 @click.option("--skip-error/--no-skip-error", help="Hide tests in errors due to connectivity issue", default=False, required=False)
-def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: bool) -> bool:
+def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: bool) -> None:
     """ANTA command to check network states with text result"""
     # pylint: disable=too-many-arguments
     custom_theme = Theme(RICH_COLOR_THEME)
     console = Console(theme=custom_theme)
-    results = check_run(
-        inventory=ctx.obj["inventory"],
-        catalog=catalog,
-        username=ctx.obj["username"],
-        password=ctx.obj["password"],
-        timeout=ctx.obj["timeout"],
-        enable_password=ctx.obj["enable_password"],
-        tags=tags,
-    )
+    results = check_run(inventory=ctx.obj["inventory"], catalog=catalog, tags=tags)
     regexp = re.compile(search)
     for line in results.get_results(output_format="list"):
         if any(regexp.match(entry) for entry in [line.name, line.test]) and (not skip_error or line.result != "error"):
             message = f" ({str(line.messages[0])})" if len(line.messages) > 0 else ""
             console.print(f"{line.name} :: {line.test} :: [{line.result}]{line.result.upper()}[/{line.result}]{message}", highlight=False)
-    return True
 
 
 @click.command()
@@ -132,15 +103,7 @@ def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, outpu
     console = Console()
     inventory = ctx.obj["inventory"]
 
-    results = check_run(
-        inventory=inventory,
-        catalog=catalog,
-        username=ctx.obj["username"],
-        password=ctx.obj["password"],
-        timeout=ctx.obj["timeout"],
-        enable_password=ctx.obj["enable_password"],
-        tags=tags,
-    )
+    results = check_run(inventory=inventory, catalog=catalog, tags=tags)
 
     # @mtache - TODO
     # if log_level.upper() == "DEBUG":

--- a/anta/cli/check/commands.py
+++ b/anta/cli/check/commands.py
@@ -13,7 +13,6 @@ from rich.panel import Panel
 from rich.theme import Theme
 
 from anta import RICH_COLOR_THEME
-from anta.cli.utils import setup_logging
 
 from .utils import check_run, display_jinja, display_json, display_table
 
@@ -30,14 +29,9 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--group-by", default=None, type=click.Choice(["none", "host", "test"], case_sensitive=False), help="Group result by test or host. default none", required=False
 )
-# Debug stuf
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: str, log_level: str) -> bool:
+def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: str) -> bool:
     """ANTA command to check network states with table result"""
     # pylint: disable=too-many-arguments
-    setup_logging(level=log_level)
     console = Console()
     inventory = ctx.obj["inventory"]
 
@@ -58,7 +52,6 @@ def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: st
         timeout=ctx.obj["timeout"],
         enable_password=ctx.obj["enable_password"],
         tags=tags,
-        loglevel=log_level,
     )
     display_table(console=console, results=results, group_by=group_by, search=search)
 
@@ -67,18 +60,12 @@ def table(ctx: click.Context, catalog: str, tags: str, group_by: str, search: st
 
 @click.command()
 @click.pass_context
-# Generic options
 @click.option("--catalog", "-c", show_envvar=True, prompt="Path for tests catalog", help="Path for tests catalog", type=click.Path(), required=True)
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
 # Options valid with --display json
 @click.option("--output", "-o", default=None, help="Path to save output in json or list", type=click.File(), required=False)
-# Debug stuf
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def json(ctx: click.Context, catalog: str, output: str, tags: str, log_level: str) -> bool:
+def json(ctx: click.Context, catalog: str, output: str, tags: str) -> bool:
     """ANTA command to check network state with JSON result"""
-    setup_logging(level=log_level)
     console = Console()
     inventory = ctx.obj["inventory"]
 
@@ -99,7 +86,6 @@ def json(ctx: click.Context, catalog: str, output: str, tags: str, log_level: st
         timeout=ctx.obj["timeout"],
         enable_password=ctx.obj["enable_password"],
         tags=tags,
-        loglevel=log_level,
     )
     display_json(console=console, results=results, output_file=output)
 
@@ -112,13 +98,9 @@ def json(ctx: click.Context, catalog: str, output: str, tags: str, log_level: st
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
 @click.option("--search", "-s", default=".*", help="Regular expression to search in both name and test", type=str, required=False)
 @click.option("--skip-error/--no-skip-error", help="Hide tests in errors due to connectivity issue", default=False, required=False)
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: bool, log_level: str) -> bool:
+def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: bool) -> bool:
     """ANTA command to check network states with text result"""
     # pylint: disable=too-many-arguments
-    setup_logging(level=log_level)
     custom_theme = Theme(RICH_COLOR_THEME)
     console = Console(theme=custom_theme)
     results = check_run(
@@ -129,7 +111,6 @@ def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: b
         timeout=ctx.obj["timeout"],
         enable_password=ctx.obj["enable_password"],
         tags=tags,
-        loglevel=log_level,
     )
     regexp = re.compile(search)
     for line in results.get_results(output_format="list"):
@@ -145,10 +126,7 @@ def text(ctx: click.Context, catalog: str, tags: str, search: str, skip_error: b
 @click.option("--template", "-tpl", type=click.Path(), required=True, help="Path to the template to use for your report")
 @click.option("--output", "-o", type=click.Path(), default=None, required=False, help="Path to use to save report")
 @click.option("--tags", "-t", default="all", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_level: str, output: str) -> bool:
+def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, output: str) -> bool:
     # pylint: disable=too-many-arguments
     """ANTA command to check network state with templated report"""
     console = Console()
@@ -162,12 +140,12 @@ def tpl_report(ctx: click.Context, catalog: str, tags: str, template: str, log_l
         timeout=ctx.obj["timeout"],
         enable_password=ctx.obj["enable_password"],
         tags=tags,
-        loglevel=log_level,
     )
 
-    if log_level.upper() == "DEBUG":
-        console.print(Panel.fit("List results of all tests", style="red"))
-        console.print(results.get_results(output_format="json"))
+    # @mtache - TODO
+    # if log_level.upper() == "DEBUG":
+    #     console.print(Panel.fit("List results of all tests", style="red"))
+    #     console.print(results.get_results(output_format="json"))
 
     console.print(
         Panel.fit(

--- a/anta/cli/check/utils.py
+++ b/anta/cli/check/utils.py
@@ -16,7 +16,6 @@ from rich.panel import Panel
 from rich.pretty import pprint
 from yaml import safe_load
 
-from anta.cli.utils import setup_logging
 from anta.inventory import AntaInventory
 from anta.loader import parse_catalog
 from anta.reporter import ReportJinja, ReportTable
@@ -26,10 +25,9 @@ from anta.runner import main
 logger = logging.getLogger(__name__)
 
 
-def check_run(inventory: str, catalog: str, username: str, password: str, enable_password: str, timeout: int, tags: Any, loglevel: str) -> ResultManager:
+def check_run(inventory: str, catalog: str, username: str, password: str, enable_password: str, timeout: int, tags: Any) -> ResultManager:
     # pylint: disable=too-many-arguments
     """Execute a run of all tests against inventory."""
-    setup_logging(level=loglevel)
 
     inventory_anta = AntaInventory.parse(inventory_file=inventory, username=username, password=password, enable_password=enable_password, timeout=timeout)
     logger.info(f"Inventory {inventory} loaded")

--- a/anta/cli/check/utils.py
+++ b/anta/cli/check/utils.py
@@ -25,12 +25,8 @@ from anta.runner import main
 logger = logging.getLogger(__name__)
 
 
-def check_run(inventory: str, catalog: str, username: str, password: str, enable_password: str, timeout: int, tags: Any) -> ResultManager:
-    # pylint: disable=too-many-arguments
+def check_run(inventory: AntaInventory, catalog: str, tags: Any) -> ResultManager:
     """Execute a run of all tests against inventory."""
-
-    inventory_anta = AntaInventory.parse(inventory_file=inventory, username=username, password=password, enable_password=enable_password, timeout=timeout)
-    logger.info(f"Inventory {inventory} loaded")
 
     # Test loader
 
@@ -41,13 +37,11 @@ def check_run(inventory: str, catalog: str, username: str, password: str, enable
 
     # Test Execution
 
-    logger.info("starting running test on inventory ...")
-
     if tags is not None:
         tags = tags.split(",") if "," in tags else [tags]
 
     results = ResultManager()
-    asyncio.run(main(results, inventory_anta, tests_catalog, tags=tags), debug=False)
+    asyncio.run(main(results, inventory, tests_catalog, tags=tags))
 
     return results
 

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -57,8 +57,8 @@ from anta.inventory import AntaInventory
     callback=setup_logging,
 )
 def anta(ctx: click.Context, inventory: AntaInventory, **kwargs) -> None:
+    # pylint: disable=unused-argument
     """Arista Network Test CLI"""
-    # pylint: disable=too-many-arguments
     ctx.ensure_object(dict)
     ctx.obj["inventory"] = inventory
 

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -15,7 +15,8 @@ from anta.cli.check import commands as check_commands
 from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
-from anta.cli.utils import setup_logging
+from anta.cli.utils import parse_inventory, setup_logging
+from anta.inventory import AntaInventory
 
 # Top level entrypoint
 
@@ -23,17 +24,19 @@ from anta.cli.utils import setup_logging
 @click.group()
 @click.pass_context
 @click.version_option(__version__)
-@click.option("--username", show_envvar=True, default="admin", help="Username to connect to EOS", required=True)
-@click.option("--password", show_envvar=True, default="arista123", help="Password to connect to EOS", required=True)
-@click.option("--timeout", show_envvar=True, default=5, help="Connection timeout (default 5)", required=False)
-@click.option("--enable-password", show_envvar=True, help="Enable password if required to connect", required=False)
+@click.option("--username", show_envvar=True, help="Username to connect to EOS", required=True)
+@click.option("--password", show_envvar=True, help="Password to connect to EOS", required=True)
+@click.option("--timeout", show_envvar=True, default=5, help="Global connection timeout", show_default=True)
+@click.option("--insecure/--secure", show_envvar=True, default=False, help="Disable SSH Host Key validation", show_default=True)
+@click.option("--enable-password", show_envvar=True, help="Enable password if required to connect")
 @click.option(
     "--inventory",
     "-i",
     show_envvar=True,
     required=True,
-    help="Path to your inventory file",
+    help="Path to the inventory YAML file",
     type=click.Path(file_okay=True, dir_okay=False, exists=True, readable=True),
+    callback=parse_inventory,
 )
 @click.option(
     "--log-level",
@@ -53,17 +56,11 @@ from anta.cli.utils import setup_logging
     ),
     callback=setup_logging,
 )
-def anta(ctx: click.Context, username: str, password: str, enable_password: str, inventory: str, timeout: int, log_level: str) -> None:
+def anta(ctx: click.Context, inventory: AntaInventory, **kwargs) -> None:
     """Arista Network Test CLI"""
     # pylint: disable=too-many-arguments
     ctx.ensure_object(dict)
     ctx.obj["inventory"] = inventory
-    ctx.obj["username"] = username
-    ctx.obj["password"] = password
-    ctx.obj["timeout"] = timeout
-    ctx.obj["enable_password"] = enable_password
-    ctx.obj["timeout"] = timeout
-    setup_logging(level=log_level)
 
 
 @anta.group()

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -7,6 +7,7 @@ ANTA CLI Baseline.
 """
 
 import logging
+from typing import Any, Dict
 
 import click
 
@@ -56,7 +57,7 @@ from anta.inventory import AntaInventory
     ),
     callback=setup_logging,
 )
-def anta(ctx: click.Context, inventory: AntaInventory, **kwargs) -> None:
+def anta(ctx: click.Context, inventory: AntaInventory, **kwargs: Dict[str, Any]) -> None:
     # pylint: disable=unused-argument
     """Arista Network Test CLI"""
     ctx.ensure_object(dict)

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -38,6 +38,7 @@ from anta.cli.utils import setup_logging
 @click.option(
     "--log-level",
     "--log",
+    show_envvar=True,
     help="ANTA logging level",
     default=logging.getLevelName(logging.INFO),
     type=click.Choice(
@@ -50,6 +51,7 @@ from anta.cli.utils import setup_logging
         ],
         case_sensitive=False,
     ),
+    callback=setup_logging,
 )
 def anta(ctx: click.Context, username: str, password: str, enable_password: str, inventory: str, timeout: int, log_level: str) -> None:
     """Arista Network Test CLI"""

--- a/anta/cli/cli.py
+++ b/anta/cli/cli.py
@@ -6,6 +6,8 @@
 ANTA CLI Baseline.
 """
 
+import logging
+
 import click
 
 from anta import __version__
@@ -13,6 +15,7 @@ from anta.cli.check import commands as check_commands
 from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
+from anta.cli.utils import setup_logging
 
 # Top level entrypoint
 
@@ -32,7 +35,23 @@ from anta.cli.get import commands as get_commands
     help="Path to your inventory file",
     type=click.Path(file_okay=True, dir_okay=False, exists=True, readable=True),
 )
-def anta(ctx: click.Context, username: str, password: str, enable_password: str, inventory: str, timeout: int) -> None:
+@click.option(
+    "--log-level",
+    "--log",
+    help="ANTA logging level",
+    default=logging.getLevelName(logging.INFO),
+    type=click.Choice(
+        [
+            logging.getLevelName(logging.CRITICAL),
+            logging.getLevelName(logging.ERROR),
+            logging.getLevelName(logging.WARNING),
+            logging.getLevelName(logging.INFO),
+            logging.getLevelName(logging.DEBUG),
+        ],
+        case_sensitive=False,
+    ),
+)
+def anta(ctx: click.Context, username: str, password: str, enable_password: str, inventory: str, timeout: int, log_level: str) -> None:
     """Arista Network Test CLI"""
     # pylint: disable=too-many-arguments
     ctx.ensure_object(dict)
@@ -42,6 +61,7 @@ def anta(ctx: click.Context, username: str, password: str, enable_password: str,
     ctx.obj["timeout"] = timeout
     ctx.obj["enable_password"] = enable_password
     ctx.obj["timeout"] = timeout
+    setup_logging(level=log_level)
 
 
 @anta.group()

--- a/anta/cli/debug/commands.py
+++ b/anta/cli/debug/commands.py
@@ -17,7 +17,6 @@ from rich.console import Console
 
 from anta.cli.debug.utils import RunArbitraryCommand
 from anta.cli.utils import EapiVersion
-from anta.inventory import AntaInventory
 from anta.models import AntaTest, AntaTestCommand, AntaTestTemplate
 
 logger = logging.getLogger(__name__)

--- a/anta/cli/debug/commands.py
+++ b/anta/cli/debug/commands.py
@@ -16,7 +16,7 @@ from rich import print_json
 from rich.console import Console
 
 from anta.cli.debug.utils import RunArbitraryCommand
-from anta.cli.utils import EapiVersion, setup_logging
+from anta.cli.utils import EapiVersion
 from anta.inventory import AntaInventory
 from anta.models import AntaTest, AntaTestCommand, AntaTestTemplate
 
@@ -30,12 +30,10 @@ templater: str = ""
 @click.option("--ofmt", type=click.Choice(["text", "json"]), default="json", help="eAPI format to use. can be text or json")
 @click.option("--api-version", "--version", type=EapiVersion(), default="latest", help="Version of the command through eAPI")
 @click.option("--device", "-d", type=str, required=True, help="Device from inventory to use")
-@click.option("--log-level", "--log", help="Logging level of the command", default="warning")
-def run_cmd(ctx: click.Context, command: str, ofmt: str, api_version: Union[int, Literal["latest"]], device: str, log_level: str) -> None:
+def run_cmd(ctx: click.Context, command: str, ofmt: str, api_version: Union[int, Literal["latest"]], device: str) -> None:
     """Run arbitrary command to an EOS device and get result using eAPI"""
     # pylint: disable=too-many-arguments
     console = Console()
-    setup_logging(level=log_level)
 
     inventory_anta = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
@@ -61,13 +59,11 @@ def run_cmd(ctx: click.Context, command: str, ofmt: str, api_version: Union[int,
 @click.option("--ofmt", type=click.Choice(["text", "json"]), default="json", help="eAPI format to use. can be text or json")
 @click.option("--api-version", "--version", type=EapiVersion(), default="latest", help="Version of the command through eAPI")
 @click.option("--device", "-d", type=str, required=True, help="Device from inventory to use")
-@click.option("--log-level", "--log", help="Logging level of the command", default="warning")
-def run_template(ctx: click.Context, template: str, params: str, ofmt: str, api_version: Union[int, Literal["latest"]], device: str, log_level: str) -> None:
+def run_template(ctx: click.Context, template: str, params: str, ofmt: str, api_version: Union[int, Literal["latest"]], device: str) -> None:
     """Run arbitrary command to an EOS device and get result using eAPI"""
     # pylint: disable=too-many-arguments
     # pylint: disable=unused-argument
     console = Console()
-    setup_logging(level=log_level)
     inventory_anta = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
     )

--- a/anta/cli/debug/commands.py
+++ b/anta/cli/debug/commands.py
@@ -32,15 +32,10 @@ templater: str = ""
 @click.option("--device", "-d", type=str, required=True, help="Device from inventory to use")
 def run_cmd(ctx: click.Context, command: str, ofmt: str, api_version: Union[int, Literal["latest"]], device: str) -> None:
     """Run arbitrary command to an EOS device and get result using eAPI"""
-    # pylint: disable=too-many-arguments
     console = Console()
 
-    inventory_anta = AntaInventory.parse(
-        inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
-    )
-
-    device_anta = [inventory_device for inventory_device in inventory_anta.get_inventory() if inventory_device.name == device][0]
-
+    # TODO - @mtache write public method to get a device from its name
+    device_anta = [inventory_device for inventory_device in ctx.obj["inventory"] if inventory_device.name == device][0]
     logger.info(f"receive device from inventory: {device_anta}")
 
     console.print(f"run command [green]{command}[/green] on [red]{device}[/red]")
@@ -64,11 +59,11 @@ def run_template(ctx: click.Context, template: str, params: str, ofmt: str, api_
     # pylint: disable=too-many-arguments
     # pylint: disable=unused-argument
     console = Console()
-    inventory_anta = AntaInventory.parse(
-        inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
-    )
-    device_anta = [inventory_device for inventory_device in inventory_anta.get_inventory() if inventory_device.name == device][0]
+
+    # TODO - @mtache write public method to get a device from its name
+    device_anta = [inventory_device for inventory_device in ctx.obj["inventory"] if inventory_device.name == device][0]
     logger.info(f"receive device from inventory: {device_anta}")
+
     console.print(f"run dynmic command [blue]{template}[/blue] with [orange]{params}[/orange] on [red]{device}[/red]")
 
     params = json.loads(params)

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -14,7 +14,6 @@ import click
 from yaml import safe_load
 
 from anta.cli.exec.utils import clear_counters_utils, collect_commands, collect_scheduled_show_tech
-from anta.cli.utils import setup_logging
 from anta.inventory import AntaInventory
 from anta.inventory.models import DEFAULT_TAG
 
@@ -23,17 +22,9 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.pass_context
-# Generic options
 @click.option("--tags", "-t", default="all", help="List of tags using coma as separator: tag1,tag2,tag3", type=str)
-# Debug stuf
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="info", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def clear_counters(ctx: click.Context, log_level: str, tags: str) -> None:
+def clear_counters(ctx: click.Context, tags: str) -> None:
     """Clear counter statistics on EOS devices"""
-
-    setup_logging(level=log_level)
-
     inventory_anta = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
     )
@@ -47,7 +38,6 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
 
 @click.command()
 @click.pass_context
-# Generic options
 @click.option("--tags", "-t", default=DEFAULT_TAG, help="List of tags using coma as separator: tag1,tag2,tag3", type=str)
 @click.option("--commands-list", "-c", show_envvar=True, type=click.Path(), help="File with list of commands to grab", required=True)
 @click.option(
@@ -60,13 +50,8 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
     default="anta_snapshot",
     callback=_get_snapshot_dir,
 )
-# Debug stuf
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="info", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def snapshot(ctx: click.Context, commands_list: str, log_level: str, output_directory: str, tags: str) -> None:
+def snapshot(ctx: click.Context, commands_list: str, output_directory: str, tags: str) -> None:
     """Collect commands output from devices in inventory"""
-    setup_logging(level=log_level)
     try:
         with open(commands_list, "r", encoding="UTF-8") as file:
             file_content = file.read()
@@ -94,20 +79,10 @@ def snapshot(ctx: click.Context, commands_list: str, log_level: str, output_dire
     required=False,
 )
 @click.option("--tags", "-t", default=DEFAULT_TAG, help="List of tags using coma as separator: tag1,tag2,tag3", type=str, required=False)
-# Debug stuf
-@click.option(
-    "--log-level",
-    "--log",
-    help="Logging level of the command",
-    default="info",
-    show_default=True,
-    type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False),
-)
 def collect_tech_support(  # pylint: disable=too-many-arguments
-    ctx: click.Context, output: str, ssh_port: int, insecure: bool, latest: int, configure: bool, log_level: str, tags: str
+    ctx: click.Context, output: str, ssh_port: int, insecure: bool, latest: int, configure: bool, tags: str
 ) -> bool:
     """Collect scheduled tech-support from eos devices."""
-    setup_logging(level=log_level)
     inventory = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
     )

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -9,12 +9,12 @@ import asyncio
 import logging
 import sys
 from datetime import datetime
+from pathlib import Path
 
 import click
 from yaml import safe_load
 
 from anta.cli.exec.utils import clear_counters_utils, collect_commands, collect_scheduled_show_tech
-from anta.inventory import AntaInventory
 from anta.inventory.models import DEFAULT_TAG
 
 logger = logging.getLogger(__name__)
@@ -25,10 +25,7 @@ logger = logging.getLogger(__name__)
 @click.option("--tags", "-t", default="all", help="List of tags using coma as separator: tag1,tag2,tag3", type=str)
 def clear_counters(ctx: click.Context, tags: str) -> None:
     """Clear counter statistics on EOS devices"""
-    inventory_anta = AntaInventory.parse(
-        inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
-    )
-    asyncio.run(clear_counters_utils(inventory_anta, ctx.obj["enable_password"], tags=tags.split(",")))
+    asyncio.run(clear_counters_utils(ctx.obj["inventory"], tags=tags.split(",")))
 
 
 def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> str:  # pylint: disable=unused-argument
@@ -59,17 +56,12 @@ def snapshot(ctx: click.Context, commands_list: str, output_directory: str, tags
     except FileNotFoundError:
         logger.error(f"Error reading {commands_list}")
         sys.exit(1)
-    inventory = AntaInventory.parse(
-        inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
-    )
-    asyncio.run(collect_commands(inventory, ctx.obj["enable_password"], eos_commands, output_directory, tags=tags.split(",")))
+    asyncio.run(collect_commands(ctx.obj["inventory"], eos_commands, output_directory, tags=tags.split(",")))
 
 
 @click.command()
 @click.pass_context
-@click.option("--output", "-o", default="./tech-support", show_default=True, help="Path for tests catalog", type=click.Path(), required=False)
-@click.option("--ssh-port", "-ssh", default=22, show_default=True, help="SSH port to use for connection", type=int, required=False)
-@click.option("--insecure/--secure", help="Disable SSH Host Key validation", default=False, show_default=True, required=False)
+@click.option("--output", "-o", default="./tech-support", show_default=True, help="Path for tests catalog", type=click.Path(path_type=Path), required=False)
 @click.option("--latest", help="Number of scheduled show-tech to retrieve", type=int, required=False)
 @click.option(
     "--configure/--not-configure",
@@ -79,12 +71,6 @@ def snapshot(ctx: click.Context, commands_list: str, output_directory: str, tags
     required=False,
 )
 @click.option("--tags", "-t", default=DEFAULT_TAG, help="List of tags using coma as separator: tag1,tag2,tag3", type=str, required=False)
-def collect_tech_support(  # pylint: disable=too-many-arguments
-    ctx: click.Context, output: str, ssh_port: int, insecure: bool, latest: int, configure: bool, tags: str
-) -> bool:
-    """Collect scheduled tech-support from eos devices."""
-    inventory = AntaInventory.parse(
-        inventory_file=ctx.obj["inventory"], username=ctx.obj["username"], password=ctx.obj["password"], enable_password=ctx.obj["enable_password"]
-    )
-    asyncio.run(collect_scheduled_show_tech(inventory, ctx.obj["enable_password"], output, tags.split(","), ssh_port, insecure, latest, configure))
-    return True
+def collect_tech_support(ctx: click.Context, output: Path, latest: int, configure: bool, tags: str) -> None:
+    """Collect scheduled tech-support from EOS devices"""
+    asyncio.run(collect_scheduled_show_tech(ctx.obj["inventory"], output, tags.split(","), latest, configure))

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -106,9 +106,10 @@ async def collect_scheduled_show_tech(
         """
         try:
             # Get the tech-support filename to retrieve
-            command = AntaTestCommand(command=f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}", ofmt="text")
+            cmd = f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}"
             if latest:
-                command.command += f" | head -{latest}"
+                cmd += f" | head -{latest}"
+            command = AntaTestCommand(command=cmd, ofmt="text")
             await device.collect(command=command)
             if command.output:
                 filenames = list(map(lambda f: Path(f"{EOS_SCHEDULED_TECH_SUPPORT}/{f}"), str(command.output).splitlines()))
@@ -129,13 +130,13 @@ async def collect_scheduled_show_tech(
                 if configure:
                     # TODO - @mtache - add `config` field to `AntaTestCommand` object to handle this use case.
                     commands = [
-                        {"cmd": "enable", "input": device._enable_password},
+                        {"cmd": "enable", "input": device._enable_password},  # type: ignore[attr-defined] # pylint: disable=protected-access
                         "configure terminal",
                         "aaa authorization exec default local",
                     ]
                     command = AntaTestCommand(command="show running-config | include aaa authorization exec default local", ofmt="text")
                     logger.debug(f"Configuring 'aaa authorization exec default local' on device {device.name}")
-                    await device.session.cli(commands=commands)
+                    await device.session.cli(commands=commands)  # type: ignore[attr-defined]
                     logger.info(f"Configured 'aaa authorization exec default local' on device {device.name}")
                 else:
                     logger.error(f"Unable to collect tech-support on {device.name}: configuration 'aaa authorization exec default local' is not present")

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -7,39 +7,38 @@ Exec CLI helpers
 
 import asyncio
 import itertools
+import json
 import logging
 import traceback
 from pathlib import Path
 from typing import Dict, List, Literal
 
-import asyncssh
 from aioeapi import EapiCommandError
 
 from anta.inventory import AntaInventory
 from anta.inventory.models import AntaDevice
+from anta.models import AntaTestCommand
+from anta.tools.misc import exc_to_str, tb_to_str
 
 EOS_SCHEDULED_TECH_SUPPORT = "/mnt/flash/schedule/tech-support"
 
 logger = logging.getLogger(__name__)
 
 
-async def clear_counters_utils(anta_inventory: AntaInventory, enable_pass: str, tags: List[str]) -> None:
+async def clear_counters_utils(anta_inventory: AntaInventory, tags: List[str]) -> None:
     """
-    clear counters
+    Clear counters
     """
 
     async def clear(dev: AntaDevice) -> None:
-        commands = [{"cmd": "enable", "input": enable_pass}, "clear counters"]
+        commands = [AntaTestCommand(command="clear counters")]
         if dev.hw_model not in ["cEOSLab", "vEOS-lab"]:
-            commands.append("clear hardware counter drop")
-        try:
-            await dev.session.cli(commands=commands)
-            logger.info(f"Cleared counters on {dev.name} ({dev.hw_model})")
-        # In this case we want to catch all exceptions
-        except Exception as e:  # pylint: disable=broad-except
-            logger.error(f"Could not clear counters on device {dev.name}")
-            logger.debug(f"Exception raised for device {dev.name} - {type(e).__name__}: {str(e)}")
-            logger.debug(traceback.format_exc())
+            commands.append(AntaTestCommand(command="clear hardware counter drop"))
+        await dev.collect_commands(commands=commands)
+        for command in commands:
+            if command.output is None:  # TODO - add a failed attribute to AntaTestCommand class
+                logger.error(f"Could not clear counters on device {dev.name}")
+        logger.info(f"Cleared counters on {dev.name} ({dev.hw_model})")
 
     logger.info("Connecting to devices...")
     await anta_inventory.connect_inventory()
@@ -50,7 +49,6 @@ async def clear_counters_utils(anta_inventory: AntaInventory, enable_pass: str, 
 
 async def collect_commands(
     inv: AntaInventory,
-    enable_pass: str,
     commands: Dict[str, str],
     root_dir: str,
     tags: List[str],
@@ -60,30 +58,20 @@ async def collect_commands(
     """
 
     async def collect(dev: AntaDevice, command: str, outformat: Literal["json", "text"]) -> None:
-        try:
-            outdir = Path() / root_dir / dev.name / outformat
-            outdir.mkdir(parents=True, exist_ok=True)
-            outfile = outdir / command
-            if enable_pass is not None:
-                result = await dev.session.cli(
-                    commands=[{"cmd": "enable", "input": enable_pass}, command],
-                    ofmt=outformat,
-                )
-            else:
-                result = await dev.session.cli(
-                    commands=["", command],
-                    ofmt=outformat,
-                )
-            with outfile.open(mode="w", encoding="UTF-8") as f:
-                f.write(str(result[1]))
-            logger.info(f"Collected command '{command}' from device {dev.name} ({dev.hw_model})")
-        except EapiCommandError as e:
-            logger.error(f"Command failed on {dev.name}: {e.errmsg}")
-        # In this case we want to catch all exceptions
-        except Exception as e:  # pylint: disable=broad-except
+        outdir = Path() / root_dir / dev.name / outformat
+        outdir.mkdir(parents=True, exist_ok=True)
+        outfile = outdir / command
+        c = AntaTestCommand(command=command, ofmt=outformat)
+        await dev.collect(c)
+        if c.output is None:
             logger.error(f"Could not collect commands on device {dev.name}")
-            logger.debug(f"Exception raised for device {dev.name} - {type(e).__name__}: {str(e)}")
-            logger.debug(traceback.format_exc())
+            return
+        with outfile.open(mode="w", encoding="UTF-8") as f:
+            if c.ofmt == "json":
+                f.write(json.dumps(c.output, indent=2))
+            elif c.ofmt == "text":
+                f.write(str(c.output))
+        logger.info(f"Collected command '{command}' from device {dev.name} ({dev.hw_model})")
 
     logger.info("Connecting to devices...")
     await inv.connect_inventory()
@@ -94,16 +82,17 @@ async def collect_commands(
     res = await asyncio.gather(*coros, return_exceptions=True)
     for r in res:
         if isinstance(r, Exception):
-            logger.error(f"Error when running tests: {r.__class__.__name__}: {r}")
+            logger.error(f"Error when collecting commands: {r.__class__.__name__}: {r}")
+    for r in res:
+        if isinstance(r, Exception):
+            logger.critical(f"Error when collecting commands - {exc_to_str(r)}")
+            logger.debug(tb_to_str(r))
 
 
-async def collect_scheduled_show_tech(  # pylint: disable=too-many-arguments
+async def collect_scheduled_show_tech(
     inv: AntaInventory,
-    enable_pass: str,
-    root_dir: str,
+    root_dir: Path,
     tags: List[str],
-    ssh_port: int,
-    insecure: bool,
     latest: int,
     configure: bool,
 ) -> None:
@@ -117,14 +106,12 @@ async def collect_scheduled_show_tech(  # pylint: disable=too-many-arguments
         """
         try:
             # Get the tech-support filename to retrieve
-            command = f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}"
+            command = AntaTestCommand(command=f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}", ofmt="text")
             if latest:
-                command += f" | head -{latest}"
-            commands = [{"cmd": "enable", "input": enable_pass}, command]
-            logger.debug(f"Sending '{command}' to device {device.name}")
-            res = await device.session.cli(commands=commands, ofmt="text")
-            if res[1]:
-                filenames = list(map(lambda f: f"{EOS_SCHEDULED_TECH_SUPPORT}/{f}", res[1].splitlines()))
+                command.command += f" | head -{latest}"
+            await device.collect(command=command)
+            if command.output:
+                filenames = list(map(lambda f: Path(f"{EOS_SCHEDULED_TECH_SUPPORT}/{f}"), str(command.output).splitlines()))
             else:
                 logger.error(f"Unable to get tech-support filenames on {device.name}: verify that {EOS_SCHEDULED_TECH_SUPPORT} is not empty")
                 return
@@ -134,21 +121,19 @@ async def collect_scheduled_show_tech(  # pylint: disable=too-many-arguments
             outdir.mkdir(parents=True, exist_ok=True)
 
             # Check if 'aaa authorization exec default local' is present in the running-config
-            commands = [
-                {"cmd": "enable", "input": enable_pass},
-                "show running-config | include aaa authorization exec default local",
-            ]
-            logger.debug(f"Sending 'show running-config | include aaa authorization exec default local' to device {device.name}")
-            res = await device.session.cli(commands=commands, ofmt="text")
+            command = AntaTestCommand(command="show running-config | include aaa authorization exec default local", ofmt="text")
+            await device.collect(command=command)
 
-            if not res[1]:
+            if not command.output:
                 logger.debug(f"'aaa authorization exec default local' is not configured on device {device.name}")
                 if configure:
+                    # TODO - @mtache - add `config` field to `AntaTestCommand` object to handle this use case.
                     commands = [
-                        {"cmd": "enable", "input": enable_pass},
+                        {"cmd": "enable", "input": device._enable_password},
                         "configure terminal",
                         "aaa authorization exec default local",
                     ]
+                    command = AntaTestCommand(command="show running-config | include aaa authorization exec default local", ofmt="text")
                     logger.debug(f"Configuring 'aaa authorization exec default local' on device {device.name}")
                     await device.session.cli(commands=commands)
                     logger.info(f"Configured 'aaa authorization exec default local' on device {device.name}")
@@ -157,21 +142,7 @@ async def collect_scheduled_show_tech(  # pylint: disable=too-many-arguments
                     return
             logger.debug(f"'aaa authorization exec default local' is already configured on device {device.name}")
 
-            ssh_params = {
-                "host": device.host,
-                "port": ssh_port,
-                "username": device.username,
-                "password": device.password,
-            }
-            if insecure:
-                ssh_params.update({"known_hosts": None})
-
-            async with asyncssh.connect(**ssh_params) as conn:
-                coros = []
-                for file in filenames:
-                    logger.info(f"Copying '{file}' from device {device.name} to '{outdir}' locally")
-                    coros.append(asyncssh.scp((conn, file), outdir))
-                await asyncio.gather(*coros)
+            await device.copy(sources=filenames, destination=outdir, direction="from")
             logger.info(f"Collected {len(filenames)} scheduled tech-support from {device.name}")
 
         except EapiCommandError as e:

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -20,7 +20,6 @@ from rich.console import Console
 from anta.cli.utils import setup_logging
 from anta.inventory import AntaInventory
 from anta.inventory.models import DEFAULT_TAG
-from anta.tools.pydantic import pydantic_to_dict
 
 from .utils import create_inventory, get_cv_token
 
@@ -100,7 +99,7 @@ def inventory(ctx: click.Context, tags: Any, connected: bool, log_level: str) ->
         asyncio.run(inventory_anta.connect_inventory())
 
     inventory_result = inventory_anta.get_inventory(tags=tags)
-    console.print_json(json.dumps(pydantic_to_dict(inventory_result), indent=2))
+    console.print_json(json.dumps(vars(inventory_result), indent=2))
 
     return True
 

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -17,7 +17,6 @@ from cvprac.cvp_client import CvpClient
 from cvprac.cvp_client_errors import CvpApiError
 from rich.console import Console
 
-from anta.cli.utils import setup_logging
 from anta.inventory import AntaInventory
 from anta.inventory.models import DEFAULT_TAG
 
@@ -32,13 +31,9 @@ logger = logging.getLogger(__name__)
 @click.option("--cvp-password", "-p", default=None, help="CVP Password / token", type=str, required=True)
 @click.option("--cvp-container", "-c", default=None, help="Container where devices are configured", type=str, required=False)
 @click.option("--inventory-directory", "-d", default=None, help="Path to save inventory file", type=click.Path())
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="info", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_password: str, cvp_container: str, log_level: str) -> bool:
+def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_password: str, cvp_container: str) -> bool:
     """Build ANTA inventory from Cloudvision"""
     # pylint: disable=too-many-arguments
-    setup_logging(level=log_level)
     logger.info(f"Getting auth token from {cvp_ip} for user {cvp_username}")
     token = get_cv_token(cvp_ip=cvp_ip, cvp_username=cvp_username, cvp_password=cvp_password)
 
@@ -72,15 +67,10 @@ def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_passw
 @click.command()
 @click.pass_context
 @click.option("--tags", "-t", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False)
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
 @click.option("--connected/--not-connected", help="Display inventory after connection has been created", default=False, required=False)
-def inventory(ctx: click.Context, tags: Any, connected: bool, log_level: str) -> bool:
+def inventory(ctx: click.Context, tags: Any, connected: bool) -> bool:
     """Show inventory loaded in ANTA."""
     console = Console()
-    setup_logging(level=log_level)
-
     inventory_anta = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"],
         username=ctx.obj["username"],
@@ -106,14 +96,9 @@ def inventory(ctx: click.Context, tags: Any, connected: bool, log_level: str) ->
 
 @click.command()
 @click.pass_context
-@click.option(
-    "--log-level", "--log", help="Logging level of the command", default="warning", type=click.Choice(["debug", "info", "warning", "critical"], case_sensitive=False)
-)
-def tags(ctx: click.Context, log_level: str) -> bool:
+def tags(ctx: click.Context) -> bool:
     """Get list of configured tags in user inventory."""
     console = Console()
-    setup_logging(level=log_level)
-
     inventory_anta = AntaInventory.parse(
         inventory_file=ctx.obj["inventory"],
         username=ctx.obj["username"],

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -9,7 +9,29 @@ import logging
 from typing import Any, Literal, Optional, Union
 
 import click
+from click import Option
 
+import anta.loader
+from anta.inventory import AntaInventory
+
+logger = logging.getLogger(__name__)
+
+
+def parse_inventory(ctx: click.Context, param: Option, value: str) -> AntaInventory:
+    try:
+        inventory = AntaInventory.parse(
+            inventory_file=value,
+            username=ctx.params["username"],
+            password=ctx.params["password"],
+            enable_password=ctx.params["enable_password"],
+            timeout=ctx.params["timeout"],
+            insecure=ctx.params["insecure"],
+        )
+        logger.info(f"Inventory {value} loaded")
+        return inventory
+    except Exception as exc:
+        ctx.fail(f"Unable to parse ANTA Inventory file '{value}': {str(exc)}")
+        return None
 
 
 def setup_logging(ctx: click.Context, param: Option, value: str) -> str:

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -9,24 +9,16 @@ import logging
 from typing import Any, Literal, Optional, Union
 
 import click
-from rich.logging import RichHandler
 
 
-def setup_logging(level: str = logging.getLevelName(logging.INFO)) -> None:
-    """
-    Configure logging
 
-    Args:
-        level (str, optional): level name to configure.
-    """
-    root = logging.getLogger()
-    if not root.hasHandlers():
-        handler = RichHandler()
-        formatter = logging.Formatter(fmt="%(message)s", datefmt="[%X]")
-        handler.setFormatter(formatter)
-        root.addHandler(handler)
-    loglevel = getattr(logging, level.upper())
-    root.setLevel(loglevel)
+def setup_logging(ctx: click.Context, param: Option, value: str) -> str:
+    try:
+        anta.loader.setup_logging(value)
+        return value
+    except Exception as exc:
+        ctx.fail(f"Unable to set ANTA logging level '{value}': {str(exc)}")
+        return None
 
 
 class EapiVersion(click.ParamType):

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -12,7 +12,7 @@ import click
 from rich.logging import RichHandler
 
 
-def setup_logging(level: str = "info") -> None:
+def setup_logging(level: str = logging.getLevelName(logging.INFO)) -> None:
     """
     Configure logging
 
@@ -20,10 +20,11 @@ def setup_logging(level: str = "info") -> None:
         level (str, optional): level name to configure.
     """
     root = logging.getLogger()
-    handler = RichHandler()
-    formatter = logging.Formatter(fmt="%(message)s", datefmt="[%X]")
-    handler.setFormatter(formatter)
-    root.addHandler(handler)
+    if not root.hasHandlers():
+        handler = RichHandler()
+        formatter = logging.Formatter(fmt="%(message)s", datefmt="[%X]")
+        handler.setFormatter(formatter)
+        root.addHandler(handler)
     loglevel = getattr(logging, level.upper())
     root.setLevel(loglevel)
 

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 def parse_inventory(ctx: click.Context, param: Option, value: str) -> AntaInventory:
+    # pylint: disable=unused-argument
+    """
+    Click option callback to parse an ANTA inventory YAML file
+    """
     try:
         inventory = AntaInventory.parse(
             inventory_file=value,
@@ -29,16 +33,20 @@ def parse_inventory(ctx: click.Context, param: Option, value: str) -> AntaInvent
         )
         logger.info(f"Inventory {value} loaded")
         return inventory
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         ctx.fail(f"Unable to parse ANTA Inventory file '{value}': {str(exc)}")
         return None
 
 
 def setup_logging(ctx: click.Context, param: Option, value: str) -> str:
+    # pylint: disable=unused-argument
+    """
+    Click option callback to set ANTA logging level
+    """
     try:
         anta.loader.setup_logging(value)
         return value
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         ctx.fail(f"Unable to set ANTA logging level '{value}': {str(exc)}")
         return None
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -56,6 +56,7 @@ class AntaInventory:
     def parse(
         inventory_file: str, username: str, password: str, enable_password: Optional[str] = None, timeout: Optional[float] = None, insecure: bool = False
     ) -> AntaInventory:
+        # pylint: disable=too-many-arguments
         """
         Create an AntaInventory object from an inventory file.
         Instantiate AntaDevice objects using the AsyncEOSDevice subclass.

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -53,7 +53,9 @@ class AntaInventory:
             return result
 
     @staticmethod
-    def parse(inventory_file: str, username: str, password: str, enable_password: Optional[str] = None, timeout: Optional[float] = None) -> AntaInventory:
+    def parse(
+        inventory_file: str, username: str, password: str, enable_password: Optional[str] = None, timeout: Optional[float] = None, insecure: bool = False
+    ) -> AntaInventory:
         """
         Create an AntaInventory object from an inventory file.
         Instantiate AntaDevice objects using the AsyncEOSDevice subclass.
@@ -71,7 +73,7 @@ class AntaInventory:
         """
 
         inventory = AntaInventory()
-        kwargs: Dict[str, Any] = {"username": username, "password": password, "enable_password": enable_password, "timeout": timeout}
+        kwargs: Dict[str, Any] = {"username": username, "password": password, "enable_password": enable_password, "timeout": timeout, "insecure": insecure}
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         with open(inventory_file, "r", encoding="UTF-8") as fd:

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -160,12 +160,12 @@ class AntaInventory:
     ###########################################################################
 
     async def connect_inventory(self) -> None:
-        """connect_inventory Helper to prepare inventory with network data."""
-        logger.debug("Refreshing facts for current inventory")
+        """Run `refresh()` coroutines for all AntaDevice objects in this inventory."""
+        logger.debug("Refreshing devices...")
         results = await asyncio.gather(
             *(device.refresh() for device in self._inventory),
             return_exceptions=True,
         )
         for r in results:
             if isinstance(r, Exception):
-                logger.error(f"Error when initiating inventory: {r.__class__.__name__}{'' if not str(r) else f' ({str(r)})'}")
+                logger.error(f"Error when refreshing inventory: {r.__class__.__name__}{'' if not str(r) else f' ({str(r)})'}")

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -309,38 +309,3 @@ class AsyncEOSDevice(AntaDevice):
         else:
             logger.warning(f"Could not connect to device {self.name}: cannot open eAPI port")
         self.established = bool(self.is_online and self.hw_model)
-
-
-class InventoryDevices(BaseModel):
-    """
-    Inventory model to list all AntaDevice entries.
-
-    Attributes:
-        __root__(List[AntaDevice]): A list of AntaDevice objects.
-    """
-
-    # pylint: disable=R0801
-
-    __root__: List[AntaDevice] = []
-
-    def append(self, value: AntaDevice) -> None:
-        """Add support for append method."""
-        self.__root__.append(value)
-
-    def __iter__(self) -> Iterator[AntaDevice]:  # type: ignore
-        """Use custom iter method."""
-        # TODO - mypy is not happy because we overwrite BaseModel.__iter__
-        # return type and are breaking Liskov Substitution Principle.
-        return iter(self.__root__)
-
-    def __getitem__(self, item: int) -> AntaDevice:
-        """Use custom getitem method."""
-        return self.__root__[item]
-
-    def __len__(self) -> int:
-        """Support for length of __root__"""
-        return len(self.__root__)
-
-    def json(self, **kwargs: Any) -> str:
-        """Returns a JSON representation of the devices"""
-        return super().json(exclude={"__root__": {"__all__": {"session"}}}, **kwargs)

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from aioeapi import Device, EapiCommandError
 from httpx import ConnectError, HTTPError
-from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr, root_validator
+from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr
 
 from anta.models import AntaTestCommand
 from anta.tools.misc import exc_to_str, tb_to_str
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 # Default values
 DEFAULT_TAG = "all"
-DEFAULT_HW_MODEL = "unset"
 
 # Pydantic models for input validation
 
@@ -73,7 +72,7 @@ class AntaInventoryHost(BaseModel):
     name: Optional[str]
     host: Union[constr(regex=RFC_1123_REGEX), IPvAnyAddress]  # type: ignore
     port: Optional[conint(gt=1, lt=65535)]  # type: ignore
-    tags: List[str] = [DEFAULT_TAG]
+    tags: Optional[List[str]]
 
 
 class AntaInventoryNetwork(BaseModel):
@@ -86,7 +85,7 @@ class AntaInventoryNetwork(BaseModel):
     """
 
     network: IPvAnyNetwork
-    tags: List[str] = [DEFAULT_TAG]
+    tags: Optional[List[str]]
 
 
 class AntaInventoryRange(BaseModel):
@@ -101,7 +100,7 @@ class AntaInventoryRange(BaseModel):
 
     start: IPvAnyAddress
     end: IPvAnyAddress
-    tags: List[str] = [DEFAULT_TAG]
+    tags: Optional[List[str]]
 
 
 class AntaInventoryInput(BaseModel):
@@ -119,42 +118,57 @@ class AntaInventoryInput(BaseModel):
     ranges: Optional[List[AntaInventoryRange]]
 
 
-# Pydantic models for inventory output structures
-
-
-class AntaDevice(BaseModel, ABC):
+class AntaDevice(ABC):
     """
     Abstract class representing a device in ANTA.
-    An implementation of this class needs must override the abstract coroutine collect().
+    An implementation of this class needs must override the abstract coroutines `collect()` and
+    `refresh()`.
 
-    Attributes:
-        name (str): Device name
-        username (str): Username to use for connection.
-        password (password): Password to use for connection.
-        enable_password (Optional[str]): enable_password to use on the device, required for some tests
-        session (Any): JSONRPC session.
-        established (bool): Flag to mark if connection is established (True) or not (False). Default: False.
-        is_online (bool): Flag to mark if host is alive (True) or not (False). Default: False.
-        hw_model (str): HW name gathered during device discovery.
-        url (str): eAPI URL to use to build session.
-        tags (List[str]): List of attached tags read from inventory file.
+    Instance attributes:
+        name: Device name
+        is_online: True if the device IP is reachable and a port can be open
+        established: True if remote command execution succeeds
+        hw_model: Hardware model of the device
+        tags: List of tags for this device
     """
 
-    class Config:  # pylint: disable=too-few-public-methods
-        """Pydantic model configuration"""
+    def __init__(self, name: str, tags: Optional[List[str]] = None) -> None:
+        """
+        Constructor of AntaDevice
 
-        arbitrary_types_allowed = True
+        Args:
+            name: Device name
+            tags: List of tags for this device
+        """
+        self.name: str = name
+        self.hw_model: Optional[str] = None
+        self.tags: List[str] = tags if tags is not None else []
+        self.is_online: bool = False
+        self.established: bool = False
 
-    name: str
-    host: Optional[Union[constr(regex=RFC_1123_REGEX), IPvAnyAddress]]  # type: ignore[valid-type]
-    username: Optional[str]
-    password: Optional[str]
-    session: Any
-    established: bool = False
-    is_online: bool = False
-    hw_model: str = DEFAULT_HW_MODEL
-    tags: List[str] = [DEFAULT_TAG]
-    timeout: float = 10.0
+        # Ensure tag 'all' is always set
+        if DEFAULT_TAG not in self.tags:
+            self.tags.append(DEFAULT_TAG)
+
+    # https://github.com/python/mypy/issues/6523
+    if TYPE_CHECKING:
+        __dict__ = {}  # type: Dict[str, Any]
+    else:
+
+        @property
+        def __dict__(self) -> dict[str, Any]:
+            """
+            Returns a dictionary that represents the AntaDevice object.
+            Can be overriden in subclasses.
+            """
+            return {
+                "name": self.name,
+                "type": self.__class__.__name__,
+                "hw_model": self.hw_model,
+                "tags": self.tags,
+                "is_online": self.is_online,
+                "established": self.established,
+            }
 
     @abstractmethod
     def __eq__(self, other: object) -> bool:
@@ -186,7 +200,7 @@ class AntaDevice(BaseModel, ABC):
         Update attributes of an AntaDevice instance.
 
         This coroutine must update the following attributes of AntaDevice:
-        - is_online: When a device IP is reachable and a port can be open
+        - is_online: When the device IP is reachable and a port can be open
         - established: When a command execution succeeds
         - hw_model: The hardware model of the device
         """
@@ -195,42 +209,74 @@ class AntaDevice(BaseModel, ABC):
 class AsyncEOSDevice(AntaDevice):
     """
     Implementation of AntaDevice for EOS using aio-eapi.
+
+    Instance attributes:
+        name: Device name
+        is_online: True if the device IP is reachable and a port can be open
+        established: True if remote command execution succeeds
+        hw_model: Hardware model of the device
+        tags: List of tags for this device
     """
 
-    host: Union[constr(regex=RFC_1123_REGEX), IPvAnyAddress]  # type: ignore[valid-type]
-    port: conint(gt=1, lt=65535)  # type: ignore[valid-type]
-    username: str
-    password: str
-    enable_password: Optional[str]
-
-    session: Device
     # Hardware model definition in show version
     HW_MODEL_KEY: str = "modelName"
 
-    @root_validator(pre=True)
-    def build_device(cls: BaseModel, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Build the device session object"""
-        if not values.get("host"):
-            values["host"] = "localhost"
-        if not values.get("port"):
-            values["port"] = "8080" if values["host"] == "localhost" else "443"
-        if values.get("tags") is not None:
-            values["tags"].append(DEFAULT_TAG)
-        else:
-            values["tags"] = [DEFAULT_TAG]
-        if values.get("session") is None:
-            proto = "http" if values["port"] in ["80", "8080"] else "https"
-            values["session"] = Device(
-                host=values["host"],
-                port=values["port"],
-                username=values.get("username"),
-                password=values.get("password"),
-                proto=proto,
-                timeout=values.get("timeout"),
-            )
-        if values.get("name") is None:
-            values["name"] = f"{values['host']}:{values['port']}"
-        return values
+    def __init__(  # pylint: disable=R0913
+        self,
+        host: str,
+        username: str,
+        password: str,
+        name: Optional[str] = None,
+        enable_password: Optional[str] = None,
+        port: Optional[int] = None,
+        ssh_port: Optional[int] = 22,
+        tags: Optional[List[str]] = None,
+        timeout: float = 10.0,
+        proto: Literal["http", "https"] = "https",
+    ) -> None:
+        """
+        Constructor of AsyncEOSDevice
+
+        Args:
+            host: Device FQDN or IP
+            username: Username to connect to eAPI and SSH
+            password: Password to connect to eAPI and SSH
+            name: Device name
+            enable_password: Password used to gain privileged access on EOS
+            proto: eAPI protocol. Value can be 'http' or 'https'
+            port: eAPI port. Defaults to 80 is proto is 'http' or 443 if proto is 'https'.
+            ssh_port: SSH port
+            tags: List of tags for this device
+            timeout: Timeout value in seconds for outgoing connections. Default to 10 secs.
+        """
+        if name is None:
+            name = f"{host}:{port}"
+        super().__init__(name, tags)
+        self._enable_password = enable_password
+        self._session: Device = Device(host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
+
+    # https://github.com/python/mypy/issues/6523
+    if TYPE_CHECKING:
+        __dict__ = {}  # type: Dict[str, Any]
+    else:
+
+        @property
+        def __dict__(self) -> dict[str, Any]:
+            """
+            Returns a dictionary that represents the AntaDevice object.
+            Can be overriden in subclasses.
+            """
+            return {
+                "name": self.name,
+                "type": self.__class__.__name__,
+                "hw_model": self.hw_model,
+                "tags": self.tags,
+                "is_online": self.is_online,
+                "established": self.established,
+                "host": self._session.host,
+                "port": self._session.port,
+                "timeout": self._session.timeout.as_dict(),
+            }
 
     def __eq__(self, other: object) -> bool:
         """
@@ -239,7 +285,7 @@ class AsyncEOSDevice(AntaDevice):
         """
         if not isinstance(other, AsyncEOSDevice):
             return False
-        return self.host == other.host and self.port == other.port
+        return self._session.host == other._session.host and self._session.port == other._session.port
 
     async def collect(self, command: AntaTestCommand) -> None:
         """
@@ -253,14 +299,14 @@ class AsyncEOSDevice(AntaDevice):
             command: the command to collect
         """
         try:
-            if self.enable_password is not None:
+            if self._enable_password is not None:
                 enable_cmd = {
                     "cmd": "enable",
-                    "input": str(self.enable_password),
+                    "input": str(self._enable_password),
                 }
             else:
                 enable_cmd = {"cmd": "enable"}
-            response = await self.session.cli(
+            response = await self._session.cli(
                 commands=[enable_cmd, command.command],
                 ofmt=command.ofmt,
                 version=command.version,
@@ -293,10 +339,10 @@ class AsyncEOSDevice(AntaDevice):
         - hw_model: The hardware model of the device
         """
         logger.debug(f"Refreshing device {self.name}")
-        self.is_online = await self.session.check_connection()
+        self.is_online = await self._session.check_connection()
         if self.is_online:
             try:
-                response = await self.session.cli(command="show version")
+                response = await self._session.cli(command="show version")
             except EapiCommandError as e:
                 logger.warning(f"Cannot get hardware information from device {self.name}: {e.errmsg}")
             except (HTTPError, ConnectError) as e:

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -6,12 +6,11 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import asyncssh
-from asyncssh import SSHClientConnection
 from aioeapi import Device, EapiCommandError
-from asyncssh import SSHClientConnectionOptions
+from asyncssh import SSHClientConnection, SSHClientConnectionOptions
 from httpx import ConnectError, HTTPError
 from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr
 from rich.pretty import pretty_repr

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -28,10 +28,9 @@ def setup_logging(level: str = logging.getLevelName(logging.INFO)) -> None:
         root.addHandler(handler)
     loglevel = getattr(logging, level.upper())
     root.setLevel(loglevel)
-    if not loglevel == logging.DEBUG:
+    if loglevel == logging.INFO:
         # asyncssh is really chatty
         logging.getLogger("asyncssh").setLevel(logging.WARNING)
-        logging.getLogger("asyncssh.sftp").setLevel(loglevel)
     logger.info(f"ANTA logging set to {level.upper()}")
 
 

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -6,9 +6,33 @@ import logging
 import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from rich.logging import RichHandler
+
 from anta.result_manager.models import TestResult
 
 logger = logging.getLogger(__name__)
+
+
+def setup_logging(level: str = logging.getLevelName(logging.INFO)) -> None:
+    """
+    Configure logging
+
+    Args:
+        level (str, optional): level name to configure.
+    """
+    root = logging.getLogger()
+    if not root.hasHandlers():
+        handler = RichHandler()
+        formatter = logging.Formatter(fmt="%(name)s - %(message)s", datefmt="[%X]")
+        handler.setFormatter(formatter)
+        root.addHandler(handler)
+    loglevel = getattr(logging, level.upper())
+    root.setLevel(loglevel)
+    if not loglevel == logging.DEBUG:
+        # asyncssh is really chatty
+        logging.getLogger("asyncssh").setLevel(logging.WARNING)
+        logging.getLogger("asyncssh.sftp").setLevel(loglevel)
+    logger.info(f"ANTA logging set to {level.upper()}")
 
 
 def parse_catalog(test_catalog: Dict[Any, Any], package: Optional[str] = None) -> List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]:

--- a/anta/models.py
+++ b/anta/models.py
@@ -4,7 +4,6 @@ Models to define a TestStructure
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -180,7 +179,7 @@ class AntaTest(ABC):
         """
         logger.debug(f"Test {self.name} on device {self.device.name}: running command outputs collection")
         try:
-            await asyncio.gather(*(self.device.collect(command=command) for command in self.instance_commands))
+            await self.device.collect_commands(self.instance_commands)
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error(f"Exception raised while collecting commands for test {self.name} (on device {self.device.name}) - {exc_to_str(e)}")
             logger.debug(tb_to_str(e))

--- a/anta/result_manager/__init__.py
+++ b/anta/result_manager/__init__.py
@@ -24,8 +24,7 @@ class ResultManager:
                 inventory_file='examples/inventory.yml',
                 username='ansible',
                 password='ansible',
-                timeout=0.5,
-                auto_connect=True
+                timeout=0.5
             )
 
         Create Result Manager:

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -44,6 +44,7 @@ async def main(
     Returns:
         any: List of results.
     """
+
     await inventory.connect_inventory()
 
     # asyncio.gather takes an iterator of the function to run concurrently.
@@ -55,6 +56,7 @@ async def main(
         template_params = test[1].get(TEST_TPL_PARAMS, [])
         coros.append(test[0](device=device, template_params=template_params).test(eos_data=None, **test_params))
 
+    logger.info("Running ANTA tests...")
     res = await asyncio.gather(*coros, return_exceptions=True)
     for r in res:
         if isinstance(r, Exception):

--- a/anta/tools/pydantic.py
+++ b/anta/tools/pydantic.py
@@ -5,18 +5,17 @@ Toolkit for ANTA to play with Pydantic.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Sequence
 
 if TYPE_CHECKING:
-    from anta.inventory.models import InventoryDevices
     from anta.result_manager.models import ListResult
 
 logger = logging.getLogger(__name__)
 
 
-def pydantic_to_dict(pydantic_list: Union[InventoryDevices, ListResult]) -> Any:
+def pydantic_to_dict(pydantic_list: ListResult) -> List[Dict[str, Sequence[Any]]]:
     """
-    Convert Pydantic object into a dict
+    Convert Pydantic object into a list of dict
 
     Mimic .dict() option from pydantic but overwrite IPv4Address nodes
 
@@ -24,7 +23,7 @@ def pydantic_to_dict(pydantic_list: Union[InventoryDevices, ListResult]) -> Any:
         pydantic_list: Iterable pydantic object
 
     Returns:
-        dict: dictionary object
+        List[Dict[str, str]]: the list of dict
     """
     result = []
     for device in pydantic_list:

--- a/docs/advanced_usages/as-python-lib.md
+++ b/docs/advanced_usages/as-python-lib.md
@@ -14,7 +14,6 @@ inventory = AntaInventory.parse(
     username="username",
     password="password",
     enable_password="enable",
-    auto_connect=True,
     timeout=1,
 )
 ```

--- a/tests/data/json_data.py
+++ b/tests/data/json_data.py
@@ -77,8 +77,7 @@ INVENTORY_DEVICE_MODEL = [
         "name": "Valid_Inventory",
         "input": [
             {"host": "1.1.1.1", "username": "arista", "password": "arista123!"},
-            {"host": "1.1.1.2", "username": "arista", "password": "arista123!"},
-            {"username": "arista", "password": "arista123!"},
+            {"host": "1.1.1.2", "username": "arista", "password": "arista123!"}
         ],
         "expected_result": "valid",
     },
@@ -86,9 +85,7 @@ INVENTORY_DEVICE_MODEL = [
         "name": "Invalid_Inventory",
         "input": [
             {"host": "1.1.1.1", "password": "arista123!"},
-            {"host": "1.1.1.1", "username": "arista"},
-            {"host": "@", "username": "arista", "password": "arista123!"},
-            {"host": "1.1.1.1/32", "username": "arista", "password": "arista123!"},
+            {"host": "1.1.1.1", "username": "arista"}
         ],
         "expected_result": "invalid",
     },

--- a/tests/units/inventory/test_inventory.py
+++ b/tests/units/inventory/test_inventory.py
@@ -1,6 +1,5 @@
 """ANTA Inventory unit tests."""
 
-import json
 import logging
 from pathlib import Path
 from typing import Any, Dict
@@ -96,36 +95,3 @@ class Test_AntaInventory:
             assert True
         else:
             assert False
-
-    @pytest.mark.parametrize("test_definition", ANTA_INVENTORY_TESTS, ids=generate_test_ids_dict)
-    def test_inventory_get_json(self, test_definition: Dict[str, Any], tmp_path: Path) -> None:
-        """Test device_get function.
-
-        Test structure:
-        ---------------
-
-        {
-            'name': 'ValidInventory_with_host_only',
-            'input': {"anta_inventory":{"hosts":[{"host":"192.168.0.17"},{"host":"192.168.0.2"}]}},
-            'expected_result': 'valid',
-            'parameters': {
-                'ipaddress_in_scope': '192.168.0.17',
-                'ipaddress_out_of_scope': '192.168.1.1',
-            }
-        }
-
-        """
-        if test_definition["expected_result"] == "invalid":
-            pytest.skip("Not concerned by the test")
-
-        if not self.check_parameter(parameter="ipaddress_in_scope", test_definition=test_definition):
-            pytest.skip("Test data has no ipaddress_in_scope parameter configured")
-
-        if not self.check_parameter(parameter="nb_hosts", test_definition=test_definition):
-            pytest.skip("Test data has no nb_hosts parameter configured")
-
-        inventory_file = self.create_inventory(content=test_definition["input"], tmp_path=tmp_path)
-        inventory_test = AntaInventory.parse(inventory_file=inventory_file, username="arista", password="arista123")
-        inventory_json = json.loads(inventory_test.get_inventory(established_only=False).json())
-        assert test_definition["parameters"]["ipaddress_in_scope"] in [d["host"] for d in inventory_json]
-        assert int(test_definition["parameters"]["nb_hosts"]) == len([d["host"] for d in inventory_json])

--- a/tests/units/inventory/test_models.py
+++ b/tests/units/inventory/test_models.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pytest
 from pydantic import ValidationError
 
-from anta.inventory.models import AntaInventoryHost, AntaInventoryInput, AntaInventoryNetwork, AntaInventoryRange, AsyncEOSDevice, InventoryDevices
+from anta.inventory.models import AntaInventoryHost, AntaInventoryInput, AntaInventoryNetwork, AntaInventoryRange, AsyncEOSDevice
 from tests.data.json_data import INVENTORY_DEVICE_MODEL, INVENTORY_MODEL, INVENTORY_MODEL_HOST, INVENTORY_MODEL_NETWORK, INVENTORY_MODEL_RANGE
 from tests.lib.utils import generate_test_ids_dict
 
@@ -354,109 +354,4 @@ class Test_InventoryDeviceModel:
             except ValidationError as exc:
                 logging.info("Error: %s", str(exc))
             else:
-                assert False
-
-    @pytest.mark.parametrize("test_definition", INVENTORY_DEVICE_MODEL, ids=generate_test_ids_dict)
-    def test_inventory_devices_len(self, test_definition: Dict[str, Any]) -> None:
-        """Test len & append methods for InventoryDevice class.
-
-         Test structure:
-         ---------------
-
-        {
-             "name": "Invalid_Inventory",
-             "input": [
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 },
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 }
-             ],
-             "expected_result": "valid"
-         }
-
-        """
-        if test_definition["expected_result"] != "valid":
-            pytest.skip("Not concerned by the test")
-        inventory_devices = InventoryDevices()
-        for entry in test_definition["input"]:
-            inventory_devices.append(AsyncEOSDevice(**entry))
-        assert len(test_definition["input"]) == len(inventory_devices)
-
-    @pytest.mark.parametrize("test_definition", INVENTORY_DEVICE_MODEL, ids=generate_test_ids_dict)
-    def test_inventory_devices_get_item(self, test_definition: Dict[str, Any]) -> None:
-        """Test __iter__ method for InventoryDevice class.
-
-         Test structure:
-         ---------------
-
-        {
-             "name": "Invalid_Inventory",
-             "input": [
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 },
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 }
-             ],
-             "expected_result": "valid"
-         }
-
-        """
-        if test_definition["expected_result"] != "valid":
-            pytest.skip("Not concerned by the test")
-        inventory_devices = InventoryDevices()
-        for entry in test_definition["input"]:
-            inventory_devices.append(AsyncEOSDevice(**entry))
-        if str(inventory_devices[0].session.host) == test_definition["input"][0]["host"]:
-            logging.info("__getitem__ function is valid")
-        else:
-            logging.error("__getitem__ is not working as expected")
-            assert False
-
-    @pytest.mark.parametrize("test_definition", INVENTORY_DEVICE_MODEL, ids=generate_test_ids_dict)
-    def test_inventory_devices_iter(self, test_definition: Dict[str, Any]) -> None:
-        """Test __getitem__ method for InventoryDevice class.
-
-         Test structure:
-         ---------------
-
-        {
-             "name": "Invalid_Inventory",
-             "input": [
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 },
-                 {
-                     'host': '1.1.1.1',
-                     'username': 'arista',
-                     'password': 'arista123!'
-                 }
-             ],
-             "expected_result": "valid"
-         }
-
-        """
-        if test_definition["expected_result"] != "valid":
-            pytest.skip("Not concerned by the test")
-        inventory_devices = InventoryDevices()
-        for entry in test_definition["input"]:
-            inventory_devices.append(AsyncEOSDevice(**entry))
-        for idx, device in enumerate(inventory_devices):
-            if str(device.host) == test_definition["input"][idx].get("host", "localhost"):
-                logging.info("__iter__ function is valid")
-            else:
-                logging.error("__iter__ is not working as expected")
                 assert False

--- a/tests/units/inventory/test_models.py
+++ b/tests/units/inventory/test_models.py
@@ -316,7 +316,7 @@ class Test_InventoryDeviceModel:
         for entity in test_definition["input"]:
             try:
                 AsyncEOSDevice(**entity)
-            except ValidationError as exc:
+            except TypeError as exc:
                 logging.warning("Error: %s", str(exc))
                 assert False
 
@@ -351,7 +351,7 @@ class Test_InventoryDeviceModel:
         for entity in test_definition["input"]:
             try:
                 AsyncEOSDevice(**entity)
-            except ValidationError as exc:
+            except TypeError as exc:
                 logging.info("Error: %s", str(exc))
             else:
                 assert False


### PR DESCRIPTION
This PR brings the following main changes:

- Do not use pydantic for AntaDevice class anymore
- Introduce optional coroutine copy() for AntaDevice
- Refactor CLI scripts to use Click callbacks