### PR TITLE
fix(anta.cli): Add --group-by in nrfu table command

### DIFF
--- a/anta/cli/nrfu/commands.py
+++ b/anta/cli/nrfu/commands.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 import click
 
+from anta.cli.console import console
 from anta.cli.utils import parse_tags, return_code
 from anta.models import AntaTest
 from anta.result_manager import ResultManager
@@ -27,13 +28,19 @@ logger = logging.getLogger(__name__)
 @click.option("--tags", "-t", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False, callback=parse_tags)
 @click.option("--device", "-d", help="Show a summary for this device", type=str, required=False)
 @click.option("--test", "-t", help="Show a summary for this test", type=str, required=False)
-def table(ctx: click.Context, tags: Optional[List[str]], device: Optional[str], test: Optional[str]) -> None:
+@click.option(
+    "--group-by", default=None, type=click.Choice(["none", "host", "test"], case_sensitive=False), help="Group result by test or host. default none", required=False
+)
+def table(ctx: click.Context, tags: Optional[List[str]], device: Optional[str], test: Optional[str], group_by: str) -> None:
     """ANTA command to check network states with table result"""
+    console.print("\n")
     print_settings(ctx)
     results = ResultManager()
     with anta_progress_bar() as AntaTest.progress:
         asyncio.run(main(results, ctx.obj["inventory"], ctx.obj["catalog"], tags=tags))
-    print_table(results=results, device=device, test=test)
+    console.print("\n")
+
+    print_table(results=results, device=device, group_by=group_by, test=test)
 
     # TODO make a util method to avoid repeating the same three line
     ignore_status = ctx.obj["ignore_status"]
@@ -58,6 +65,7 @@ def json(ctx: click.Context, tags: Optional[List[str]], output: Optional[pathlib
     results = ResultManager()
     with anta_progress_bar() as AntaTest.progress:
         asyncio.run(main(results, ctx.obj["inventory"], ctx.obj["catalog"], tags=tags))
+    console.print("\n")
     print_json(results=results, output=output)
 
     ignore_status = ctx.obj["ignore_status"]
@@ -76,6 +84,7 @@ def text(ctx: click.Context, tags: Optional[List[str]], search: Optional[str], s
     results = ResultManager()
     with anta_progress_bar() as AntaTest.progress:
         asyncio.run(main(results, ctx.obj["inventory"], ctx.obj["catalog"], tags=tags))
+    console.print("\n")
     print_text(results=results, search=search, skip_error=skip_error)
 
     ignore_status = ctx.obj["ignore_status"]
@@ -108,6 +117,7 @@ def tpl_report(ctx: click.Context, tags: Optional[List[str]], template: pathlib.
     results = ResultManager()
     with anta_progress_bar() as AntaTest.progress:
         asyncio.run(main(results, ctx.obj["inventory"], ctx.obj["catalog"], tags=tags))
+    console.print("\n")
     print_jinja(results=results, template=template, output=output)
 
     ignore_status = ctx.obj["ignore_status"]

--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -34,15 +34,19 @@ def print_settings(context: click.Context, report_template: Optional[pathlib.Pat
     console.print(Panel.fit(message, style="cyan", title="[green]Settings"))
 
 
-def print_table(results: ResultManager, device: Optional[str] = None, test: Optional[str] = None) -> None:
+def print_table(results: ResultManager, device: Optional[str] = None, test: Optional[str] = None, group_by: Optional[str] = None) -> None:
     """Print result in a table"""
     reporter = ReportTable()
-    if device:
-        console.print(reporter.report_summary_hosts(result_manager=results, host=device))
-    if test:
-        console.print(reporter.report_summary_tests(result_manager=results, testcase=test))
-    if device is None and test is None:
+    if device or test:
+        message = "The test and device options are not supported yet."
+        console.print(Panel.fit(message, style="red", title="[red]Warning"))
+        console.print("\n")
+    if group_by is None:
         console.print(reporter.report_all(result_manager=results))
+    elif group_by == "host":
+        console.print(reporter.report_summary_hosts(result_manager=results, host=None))
+    elif group_by == "test":
+        console.print(reporter.report_summary_tests(result_manager=results, testcase=None))
 
 
 def print_json(results: ResultManager, output: Optional[pathlib.Path] = None) -> None:
@@ -110,6 +114,7 @@ def anta_progress_bar() -> Progress:
     """
     Return a customized Progress for progress bar
     """
+    console.print("\n")
     return Progress(
         SpinnerColumn("anta"),
         TextColumn("•"),


### PR DESCRIPTION
Add `--group-by` option removed in 0.6.0 to provides summary view based on
a per host or per test approach.

