### PR TITLE
feat(anta.cli): Add support for creating ANTA inventory from Ansible

### DIFF
--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -130,6 +130,7 @@ _exec.add_command(exec_commands.snapshot)
 _exec.add_command(exec_commands.collect_tech_support)
 
 get.add_command(get_commands.from_cvp)
+get.add_command(get_commands.from_ansible)
 get.add_command(get_commands.inventory)
 get.add_command(get_commands.tags)
 

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -66,7 +66,7 @@ def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_passw
 
 
 @click.command(no_args_is_help=True)
-@click.option("--ansible-group", "-g", default=None, help="Ansible group to filter", type=str, required=False)
+@click.option("--ansible-group", "-g", help="Ansible group to filter", type=str, required=False)
 @click.option(
     "--ansible-inventory",
     "-i",

--- a/anta/cli/get/utils.py
+++ b/anta/cli/get/utils.py
@@ -7,7 +7,7 @@ Utils functions to use with anta.cli.get.commands module.
 
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import requests
 import urllib3
@@ -32,9 +32,9 @@ def get_cv_token(cvp_ip: str, cvp_username: str, cvp_password: str) -> str:
     return response.json()["sessionId"]
 
 
-def create_inventory(inv: List[Dict[str, Any]], directory: str, container: str) -> None:
+def create_inventory_from_cvp(inv: List[Dict[str, Any]], directory: str, container: str) -> None:
     """
-    create an inventory file
+    create an inventory file from Arista CloudVision
     """
     i: Dict[str, Dict[str, Any]] = {AntaInventory.INVENTORY_ROOT_KEY: {"hosts": []}}
     logger.debug(f"Received {len(inv)} device(s) from CVP")
@@ -44,6 +44,40 @@ def create_inventory(inv: List[Dict[str, Any]], directory: str, container: str) 
     # write the devices IP address in a file
     inv_file = "inventory" if container is None else f"inventory-{container}"
     out_file = f"{directory}/{inv_file}.yml"
+    with open(out_file, "w", encoding="UTF-8") as out_fd:
+        out_fd.write(yaml.dump(i))
+    logger.info(f"Inventory file has been created in {out_file}")
+
+
+def create_inventory_from_ansible(inventory: str, directory: str, ansible_root: str = None, output_file: str = 'inventory.yml') -> None:
+    def deep_yaml_parsing(data: Dict[str, Any], hosts: Union[None, List[Dict[str, str]]] = None) -> Union[None, List[Dict[str, str]]]:
+        """Deep parsing of YAML file to extract hosts and associated IPs"""
+        if hosts is None:
+            hosts = []
+        for key, value in data.items():
+            if isinstance(value, dict) and "ansible_host" in value.keys():
+                hosts.append({"name": key, "host": value["ansible_host"]})
+            elif isinstance(value, dict):
+                deep_yaml_parsing(value, hosts)
+            else:
+                # print(f"Key: {key}\n  Value: {value}")
+                return hosts
+        return hosts
+
+    i: Dict[str, Dict[str, Any]] = {AntaInventory.INVENTORY_ROOT_KEY: {"hosts": []}}
+    ansible_inventory = yaml.safe_load(open(inventory))
+    if ansible_root not in ansible_inventory.keys():
+        logger.error(f"Group {ansible_root} not in ansible inventory {inventory}")
+        raise (f"Group {ansible_root} not in ansible inventory {inventory}")
+    if ansible_root is None:
+        ansible_hosts = deep_yaml_parsing(ansible_inventory, hosts=[])
+    else:
+        ansible_hosts = deep_yaml_parsing(ansible_inventory[ansible_root], hosts=[])
+    for dev in ansible_hosts:
+        logger.info(f'   * adding entry for {dev["name"]}')
+        print(f"   * adding entry for {dev}")
+        i[AntaInventory.INVENTORY_ROOT_KEY]["hosts"].append({"host": dev["host"], "name": dev["name"]})
+    out_file = f"{directory}/{output_file}.yml"
     with open(out_file, "w", encoding="UTF-8") as out_fd:
         out_fd.write(yaml.dump(i))
     logger.info(f"Inventory file has been created in {out_file}")

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -1,0 +1,61 @@
+# Create an Inventory from Ansible inventory
+
+In large setups, it might be beneficial to construct your inventory based on your Ansible inventory. The `from-ansible` entrypoint of the `get` command enables the user to create an ANTA inventory from Ansible.
+
+### Command overview
+
+```bash
+anta get from-ansible --help
+Usage: anta get from-ansible [OPTIONS]
+
+  Build ANTA inventory from an ansible inventory YAML file
+
+Options:
+  -g, --ansible-group TEXT        Ansible group to filter
+  -i, --ansible-inventory FILENAME
+                                  Path to your ansible inventory file to read
+  -o, --output FILENAME           Path to save inventory file
+  -d, --inventory-directory PATH  Directory to save inventory file
+  --help                          Show this message and exit.
+```
+
+The output is an inventory where the name of the container is added as a tag for each host:
+
+```yaml
+anta_inventory:
+  hosts:
+  - host: 10.73.252.41
+    name: srv-pod01
+  - host: 10.73.252.42
+    name: srv-pod02
+  - host: 10.73.252.43
+    name: srv-pod03
+```
+
+!!! warning
+    The current implementation only considers devices directly attached to a specific Ansible group and does not support inheritence when using the `--ansible-group` option.
+
+`host` value is coming from the `ansible_host` key in your inventory while `name` is the name you defined for your host. Below is an ansible inventory example used to generate previous inventory:
+
+```yaml
+---
+tooling:
+  children:
+    endpoints:
+      hosts:
+        srv-pod01:
+          ansible_httpapi_port: 9023
+          ansible_port: 9023
+          ansible_host: 10.73.252.41
+          type: endpoint
+        srv-pod02:
+          ansible_httpapi_port: 9024
+          ansible_port: 9024
+          ansible_host: 10.73.252.42
+          type: endpoint
+        srv-pod03:
+          ansible_httpapi_port: 9025
+          ansible_port: 9025
+          ansible_host: 10.73.252.43
+          type: endpoint
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
     - NRFU: cli/nrfu.md
     - Execute commands: cli/exec.md
     - Inventory from CVP: cli/inv-from-cvp.md
+    - Inventory from Ansible: cli/inv-from-ansible.md
     - Get Inventory Information: cli/get-inventory-information.md
     - Helpers: cli/debug.md
   - Advanced Usages:
@@ -187,7 +188,7 @@ nav:
     - System: api/tests.system.md
     - VXLAN: api/tests.vxlan.md
   - API Documentation:
-    - Inventory: 
+    - Inventory:
       - Inventory module: api/inventory.md
       - Inventory models: api/inventory.models.input.md
     - Device:


### PR DESCRIPTION
## Overview

Add a new command to create ANTA inventory from an Ansible inventory file:

### Command options

```
anta get from-ansible --help
Usage: anta get from-ansible [OPTIONS]

  Build ANTA inventory from an ansible inventory YAML file

Options:
  -g, --ansible-group TEXT        Ansible group to filter
  -i, --ansible-inventory FILENAME
                                  Path to your ansible inventory file to read
  -o, --output FILENAME           Path to save inventory file
  -d, --inventory-directory PATH  Directory to save inventory file
  --help                          Show this message and exit.
```

### Example

```
anta get from-ansible -i .personal/ansible-avd-inv.yml -d .personal -o demo.yml -g tooling
   * adding entry for {'name': 'srv-pod01', 'host': '10.73.252.41'}
   * adding entry for {'name': 'srv-pod02', 'host': '10.73.252.42'}
   * adding entry for {'name': 'srv-pod03', 'host': '10.73.252.43'}
```

## Supported features

- Ansible inventory using YAML file only
- Group filtering to get only a subset of inventory
- Extract Hostname and IP address

## Known limitations

- No support for `ini` format
- No support of group inheritance for device definition
