### PR TITLE
feat(anta.tests)!: Update Hardware tests

### DIFF
--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -205,7 +205,7 @@ class VerifyEnvironmentPower(AntaTest):
         Run VerifyEnvironmentPower validation
 
         Args:
-            accepted_states: Accepted states list for power supplies status. Defaults to ['ok'].
+            accepted_states: Accepted states list for power supplies status.
         """
         if not accepted_states:
             self.result.is_skipped(f"{self.__class__.name} was not run because accepted_states list was not provided")

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -1,5 +1,5 @@
 """
-Test functions related to the hardware or environement
+Test functions related to the hardware or environment
 """
 from __future__ import annotations
 
@@ -11,11 +11,16 @@ from anta.models import AntaCommand, AntaTest
 
 class VerifyTransceiversManufacturers(AntaTest):
     """
-    Verifies Manufacturers of all Transceivers.
+    This test verifies if all the transceivers come from approved manufacturers.
+
+    Expected Results:
+      * success: The test will pass if all transceivers are from approved manufacturers.
+      * failure: The test will fail if some transceivers are from unapproved manufacturers.
+      * skipped: The test will be skipped if a list of approved manufacturers is not provided or if it's run on a virtualized platform.
     """
 
     name = "VerifyTransceiversManufacturers"
-    description = ""
+    description = "Verifies the transceiver's manufacturer against a list of approved manufacturers."
     categories = ["hardware"]
     commands = [AntaCommand(command="show inventory", ofmt="json")]
 
@@ -26,56 +31,70 @@ class VerifyTransceiversManufacturers(AntaTest):
         Run VerifyTransceiversManufacturers validation
 
         Args:
-            manufacturers: List of allowed transceivers manufacturers.
+            manufacturers: List of approved transceivers manufacturers.
         """
         if not manufacturers:
-            self.result.is_skipped(f"{self.__class__.name} was not run as no manufacturers were given")
+            self.result.is_skipped(f"{self.__class__.name} was not run because manufacturers list was not provided")
+            return
+
+        command_output = self.instance_commands[0].json_output
+        wrong_manufacturers = {interface: value["mfgName"] for interface, value in command_output["xcvrSlots"].items() if value["mfgName"] not in manufacturers}
+        if not wrong_manufacturers:
+            self.result.is_success()
         else:
-            command_output = self.instance_commands[0].json_output
-            wrong_manufacturers = {interface: value["mfgName"] for interface, value in command_output["xcvrSlots"].items() if value["mfgName"] not in manufacturers}
-            if not wrong_manufacturers:
-                self.result.is_success()
-            else:
-                self.result.is_failure("The following interfaces have transceivers from unauthorized manufacturers")
-                self.result.messages.append(str(wrong_manufacturers))
+            self.result.is_failure(f"Some transceivers are from unapproved manufacturers: {wrong_manufacturers}")
 
 
 class VerifyTemperature(AntaTest):
     """
-    Verifies device temparture is currently OK (temperatureOK).
+    This test verifies if the device temperature is within acceptable limits.
+
+    Expected Results:
+      * success: The test will pass if the device temperature is currently OK: 'temperatureOk'.
+      * failure: The test will fail if the device temperature is NOT OK.
+      * skipped: Test test will be skipped if it's run on a virtualized platform.
     """
 
     name = "VerifyTemperature"
-    description = "Verifies device temparture is currently OK (temperatureOK)"
+    description = "Verifies if the device temperature is within the acceptable range."
     categories = ["hardware"]
     commands = [AntaCommand(command="show system environment temperature", ofmt="json")]
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
-        """Run VerifyTemperature validation"""
+        """
+        Run VerifyTemperature validation
+        """
         command_output = self.instance_commands[0].json_output
         temperature_status = command_output["systemStatus"] if "systemStatus" in command_output.keys() else ""
         if temperature_status == "temperatureOk":
             self.result.is_success()
         else:
-            self.result.is_failure(f"Device temperature is not OK, systemStatus: {temperature_status }")
+            self.result.is_failure(f"Device temperature exceeds acceptable limits. Current system status: '{temperature_status}'")
 
 
 class VerifyTransceiversTemperature(AntaTest):
     """
-    Verifies Transceivers temperature is currently OK.
+    This test verifies if all the transceivers are operating at an acceptable temperature.
+
+    Expected Results:
+          * success: The test will pass if all transceivers status are OK: 'ok'.
+          * failure: The test will fail if some transceivers are NOT OK.
+          * skipped: Test test will be skipped if it's run on a virtualized platform.
     """
 
     name = "VerifyTransceiversTemperature"
-    description = "Verifies Transceivers temperature is currently OK"
+    description = "Verifies that all transceivers are operating within the acceptable temperature range."
     categories = ["hardware"]
     commands = [AntaCommand(command="show system environment temperature transceiver", ofmt="json")]
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
-        """Run VerifyTransceiversTemperature validation"""
+        """
+        Run VerifyTransceiversTemperature validation
+        """
         command_output = self.instance_commands[0].json_output
         sensors = command_output["tempSensors"] if "tempSensors" in command_output.keys() else ""
         wrong_sensors = {
@@ -89,42 +108,51 @@ class VerifyTransceiversTemperature(AntaTest):
         if not wrong_sensors:
             self.result.is_success()
         else:
-            self.result.is_failure("The following sensors do not have the correct temperature or had alarms in the past:")
-            self.result.messages.append(str(wrong_sensors))
+            self.result.is_failure(f"The following sensors are operating outside the acceptable temperature range or have raised alerts: {wrong_sensors}")
 
 
 class VerifyEnvironmentSystemCooling(AntaTest):
     """
-    Verifies the System Cooling is ok.
+    This test verifies the device's system cooling.
+
+    Expected Results:
+      * success: The test will pass if the system cooling status is OK: 'coolingOk'.
+      * failure: The test will fail if the system cooling status is NOT OK.
+      * skipped: The test will be skipped if it's run on a virtualized platform.
     """
 
     name = "VerifyEnvironmentSystemCooling"
-    description = "Verifies the fans status is OK for fans"
+    description = "Verifies the system cooling status."
     categories = ["hardware"]
     commands = [AntaCommand(command="show system environment cooling", ofmt="json")]
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
-        """Run VerifyEnvironmentCooling validation"""
+        """
+        Run VerifyEnvironmentCooling validation
+        """
 
         command_output = self.instance_commands[0].json_output
         sys_status = command_output["systemStatus"] if "systemStatus" in command_output.keys() else ""
 
         self.result.is_success()
         if sys_status != "coolingOk":
-            self.result.is_failure(f"Device System cooling is not OK: {sys_status}")
+            self.result.is_failure(f"Device system cooling is not OK: '{sys_status}'")
 
 
 class VerifyEnvironmentCooling(AntaTest):
     """
-    Verifies the fans status is in the accepted states list.
+    This test verifies the fans status.
 
-    Default accepted states list is ['ok']
+    Expected Results:
+      * success: The test will pass if the fans status are within the accepted states list.
+      * failure: The test will fail if some fans status is not within the accepted states list.
+      * skipped: The test will be skipped if the accepted states list is not provided or if it's run on a virtualized platform.
     """
 
     name = "VerifyEnvironmentCooling"
-    description = "Verifies the fans status is OK for fans"
+    description = "Verifies if the fans status are within the accepted states list."
     categories = ["hardware"]
     commands = [AntaCommand(command="show system environment cooling", ofmt="json")]
 
@@ -135,10 +163,11 @@ class VerifyEnvironmentCooling(AntaTest):
         Run VerifyEnvironmentCooling validation
 
         Args:
-            accepted_states: Accepted states list for fan status
+            accepted_states: Accepted states list for fan status.
         """
-        if accepted_states is None:
-            accepted_states = ["ok"]
+        if not accepted_states:
+            self.result.is_skipped(f"{self.__class__.name} was not run because accepted_states list was not provided")
+            return
 
         command_output = self.instance_commands[0].json_output
         self.result.is_success()
@@ -146,27 +175,26 @@ class VerifyEnvironmentCooling(AntaTest):
         for power_supply in command_output.get("powerSupplySlots", []):
             for fan in power_supply.get("fans", []):
                 if (state := fan["status"]) not in accepted_states:
-                    if self.result.result == "success":
-                        self.result.is_failure(f"Some fans state are not in the accepted list: {accepted_states}.")
-                    self.result.is_failure(f"Fan {fan['label']} on PowerSupply {power_supply['label']} has state '{state}'.")
-        # Then go through Fan Trays
+                    self.result.is_failure(f"Fan {fan['label']} on PowerSupply {power_supply['label']} is: '{state}'")
+        # Then go through fan trays
         for fan_tray in command_output.get("fanTraySlots", []):
             for fan in fan_tray.get("fans", []):
                 if (state := fan["status"]) not in accepted_states:
-                    if self.result.result == "success":
-                        self.result.is_failure(f"Some fans state are not in the accepted list: {accepted_states}.")
-                    self.result.is_failure(f"Fan {fan['label']} on Fan Tray {fan_tray['label']} has state '{state}'.")
+                    self.result.is_failure(f"Fan {fan['label']} on Fan Tray {fan_tray['label']} is: '{state}'")
 
 
 class VerifyEnvironmentPower(AntaTest):
     """
-    Verifies the power supplies status is in the accepted states list
+    This test verifies the power supplies status.
 
-    The default accepted states list is ['ok']
+    Expected Results:
+      * success: The test will pass if the power supplies status are within the accepted states list.
+      * failure: The test will fail if some power supplies status is not within the accepted states list.
+      * skipped: The test will be skipped if the accepted states list is not provided or if it's run on a virtualized platform.
     """
 
     name = "VerifyEnvironmentPower"
-    description = "Verifies the power supplies status is OK"
+    description = "Verifies if the power supplies status are within the accepted states list."
     categories = ["hardware"]
     commands = [AntaCommand(command="show system environment power", ofmt="json")]
 
@@ -177,10 +205,12 @@ class VerifyEnvironmentPower(AntaTest):
         Run VerifyEnvironmentPower validation
 
         Args:
-            accepted_states: Accepted states list for power supplies
+            accepted_states: Accepted states list for power supplies status. Defaults to ['ok'].
         """
-        if accepted_states is None:
-            accepted_states = ["ok"]
+        if not accepted_states:
+            self.result.is_skipped(f"{self.__class__.name} was not run because accepted_states list was not provided")
+            return
+
         command_output = self.instance_commands[0].json_output
         power_supplies = command_output["powerSupplies"] if "powerSupplies" in command_output.keys() else "{}"
         wrong_power_supplies = {
@@ -189,27 +219,33 @@ class VerifyEnvironmentPower(AntaTest):
         if not wrong_power_supplies:
             self.result.is_success()
         else:
-            self.result.is_failure(f"The following power supplies states are not in the accepted_states list {accepted_states}")
-            self.result.messages.append(str(wrong_power_supplies))
+            self.result.is_failure(f"The following power supplies status are not in the accepted states list: {wrong_power_supplies}")
 
 
 class VerifyAdverseDrops(AntaTest):
     """
-    Verifies there is no adverse drops on DCS7280E and DCS7500E.
+    This test verifies if there are no adverse drops on DCS7280E and DCS7500E.
+
+    Expected Results:
+      * success: The test will pass if there are no adverse drops.
+      * failure: The test will fail if there are adverse drops.
+      * skipped: The test will be skipped if it's run on a virtualized platform.
     """
 
     name = "VerifyAdverseDrops"
-    description = "Verifies there is no adverse drops on DCS7280E and DCS7500E"
+    description = "Verifies there are no adverse drops on DCS7280E and DCS7500E"
     categories = ["hardware"]
     commands = [AntaCommand(command="show hardware counter drop", ofmt="json")]
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
-        """Run VerifyAdverseDrops validation"""
+        """
+        Run VerifyAdverseDrops validation
+        """
         command_output = self.instance_commands[0].json_output
         total_adverse_drop = command_output["totalAdverseDrops"] if "totalAdverseDrops" in command_output.keys() else ""
         if total_adverse_drop == 0:
             self.result.is_success()
         else:
-            self.result.is_failure(f"Device TotalAdverseDrops counter is {total_adverse_drop}")
+            self.result.is_failure(f"Device totalAdverseDrops counter is: '{total_adverse_drop}'")

--- a/tests/units/anta_tests/hardware/data.py
+++ b/tests/units/anta_tests/hardware/data.py
@@ -29,7 +29,21 @@ INPUT_MANUFACTURER: List[Dict[str, Any]] = [
         ],
         "side_effect": ["Arista"],
         "expected_result": "failure",
-        "expected_messages": ["The following interfaces have transceivers from unauthorized manufacturers", "{'1': 'Arista Networks', '2': 'Arista Networks'}"],
+        "expected_messages": ["Some transceivers are from unapproved manufacturers: {'1': 'Arista Networks', '2': 'Arista Networks'}"],
+    },
+    {
+        "name": "skipped",
+        "eos_data": [
+            {
+                "xcvrSlots": {
+                    "1": {"mfgName": "Arista Networks", "modelName": "QSFP-100G-DR", "serialNum": "XKT203501340", "hardwareRev": "21"},
+                    "2": {"mfgName": "Arista Networks", "modelName": "QSFP-100G-DR", "serialNum": "XKT203501337", "hardwareRev": "21"},
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "skipped",
+        "expected_messages": ["VerifyTransceiversManufacturers was not run because manufacturers list was not provided"],
     },
 ]
 
@@ -65,7 +79,7 @@ INPUT_TEMPERATURE: List[Dict[str, Any]] = [
         ],
         "side_effect": "",
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": ["Device temperature exceeds acceptable limits. Current system status: 'temperatureKO'"],
     },
 ]
 
@@ -128,7 +142,11 @@ INPUT_TEMPERATURE_TRANSCEIVER: List[Dict[str, Any]] = [
         ],
         "side_effect": "",
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": [
+            "The following sensors are operating outside the acceptable temperature range or have raised alerts: "
+            "{'DomTemperatureSensor54': "
+            "{'hwStatus': 'ko', 'alertCount': 0}}"
+        ],
     },
     {
         "name": "failure-alertCount",
@@ -158,7 +176,11 @@ INPUT_TEMPERATURE_TRANSCEIVER: List[Dict[str, Any]] = [
         ],
         "side_effect": "",
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": [
+            "The following sensors are operating outside the acceptable temperature range or have raised alerts: "
+            "{'DomTemperatureSensor54': "
+            "{'hwStatus': 'ok', 'alertCount': 1}}"
+        ],
     },
 ]
 
@@ -207,13 +229,13 @@ INPUT_SYSTEM_COOLING: List[Dict[str, Any]] = [
         ],
         "side_effect": "",
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": ["Device system cooling is not OK: 'coolingKo'"],
     },
 ]
 
 INPUT_COOLING: List[Dict[str, Any]] = [
     {
-        "name": "success-no-list",
+        "name": "success",
         "eos_data": [
             {
                 "defaultZones": False,
@@ -341,12 +363,12 @@ INPUT_COOLING: List[Dict[str, Any]] = [
                 "systemStatus": "coolingOk",
             }
         ],
-        "side_effect": None,
+        "side_effect": ["ok"],
         "expected_result": "success",
         "expected_messages": [],
     },
     {
-        "name": "success-more-states",
+        "name": "success-additional-states",
         "eos_data": [
             {
                 "defaultZones": False,
@@ -479,7 +501,140 @@ INPUT_COOLING: List[Dict[str, Any]] = [
         "expected_messages": [],
     },
     {
-        "name": "failure",
+        "name": "failure-fan-tray",
+        "eos_data": [
+            {
+                "defaultZones": False,
+                "numCoolingZones": [],
+                "coolingMode": "automatic",
+                "ambientTemperature": 24.5,
+                "shutdownOnInsufficientFans": True,
+                "airflowDirection": "frontToBackAirflow",
+                "overrideFanSpeed": 0,
+                "powerSupplySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498937.0240965,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499033.0403435,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply1/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498935.9121106,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499092.4665174,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply2/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply2",
+                    },
+                ],
+                "fanTraySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "down",
+                                "uptime": 1682498923.9303148,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0139885,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 29,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "1/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9304729,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498939.9329433,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "2/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "2",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "Not Inserted",
+                                "uptime": 1682498923.9383528,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140095,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "3/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "4",
+                    },
+                ],
+                "minFanSpeed": 0,
+                "currentZones": 1,
+                "configuredZones": 0,
+                "systemStatus": "CoolingKo",
+            }
+        ],
+        "side_effect": ["ok", "Not Inserted"],
+        "expected_result": "failure",
+        "expected_messages": ["Fan 1/1 on Fan Tray 1 is: 'down'"],
+    },
+    {
+        "name": "failure-power-supply",
         "eos_data": [
             {
                 "defaultZones": False,
@@ -607,9 +762,142 @@ INPUT_COOLING: List[Dict[str, Any]] = [
                 "systemStatus": "CoolingKo",
             }
         ],
-        "side_effect": None,
+        "side_effect": ["ok", "Not Inserted"],
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": ["Fan PowerSupply1/1 on PowerSupply PowerSupply1 is: 'down'"],
+    },
+    {
+        "name": "skipped",
+        "eos_data": [
+            {
+                "defaultZones": False,
+                "numCoolingZones": [],
+                "coolingMode": "automatic",
+                "ambientTemperature": 24.5,
+                "shutdownOnInsufficientFans": True,
+                "airflowDirection": "frontToBackAirflow",
+                "overrideFanSpeed": 0,
+                "powerSupplySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498937.0240965,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499033.0403435,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply1/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498935.9121106,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499092.4665174,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply2/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply2",
+                    },
+                ],
+                "fanTraySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303148,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0139885,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 29,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "1/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9304729,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498939.9329433,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "2/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "2",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "Not Inserted",
+                                "uptime": 1682498923.9383528,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140095,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "3/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            }
+                        ],
+                        "speed": 30,
+                        "label": "4",
+                    },
+                ],
+                "minFanSpeed": 0,
+                "currentZones": 1,
+                "configuredZones": 0,
+                "systemStatus": "CoolingKo",
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "skipped",
+        "expected_messages": ["VerifyEnvironmentCooling was not run because accepted_states list was not provided"],
     },
 ]
 
@@ -657,12 +945,12 @@ INPUT_ENV_POWER: List[Dict[str, Any]] = [
                 }
             }
         ],
-        "side_effect": None,
+        "side_effect": ["ok"],
         "expected_result": "success",
         "expected_messages": [],
     },
     {
-        "name": "success-additional-state",
+        "name": "success-additional-states",
         "eos_data": [
             {
                 "powerSupplies": {
@@ -751,14 +1039,71 @@ INPUT_ENV_POWER: List[Dict[str, Any]] = [
                 }
             }
         ],
-        "side_effect": None,
+        "side_effect": ["ok"],
         "expected_result": "failure",
-        "expected_messages": [],
+        "expected_messages": ["The following power supplies status are not in the accepted states list: {'1': {'state': 'powerLoss'}}"],
+    },
+    {
+        "name": "skipped",
+        "eos_data": [
+            {
+                "powerSupplies": {
+                    "1": {
+                        "outputPower": 0.0,
+                        "modelName": "PWR-500AC-F",
+                        "capacity": 500.0,
+                        "tempSensors": {
+                            "TempSensorP1/2": {"status": "ok", "temperature": 0.0},
+                            "TempSensorP1/3": {"status": "ok", "temperature": 0.0},
+                            "TempSensorP1/1": {"status": "ok", "temperature": 0.0},
+                        },
+                        "fans": {"FanP1/1": {"status": "ok", "speed": 33}},
+                        "state": "ok",
+                        "inputCurrent": 0.0,
+                        "dominant": False,
+                        "inputVoltage": 0.0,
+                        "outputCurrent": 0.0,
+                        "managed": True,
+                    },
+                    "2": {
+                        "outputPower": 117.375,
+                        "uptime": 1682498935.9121966,
+                        "modelName": "PWR-500AC-F",
+                        "capacity": 500.0,
+                        "tempSensors": {
+                            "TempSensorP2/1": {"status": "ok", "temperature": 39.0},
+                            "TempSensorP2/3": {"status": "ok", "temperature": 43.0},
+                            "TempSensorP2/2": {"status": "ok", "temperature": 31.0},
+                        },
+                        "fans": {"FanP2/1": {"status": "ok", "speed": 33}},
+                        "state": "ok",
+                        "inputCurrent": 0.572265625,
+                        "dominant": False,
+                        "inputVoltage": 232.5,
+                        "outputCurrent": 9.828125,
+                        "managed": True,
+                    },
+                }
+            }
+        ],
+        "side_effect": [],
+        "expected_result": "skipped",
+        "expected_messages": ["VerifyEnvironmentPower was not run because accepted_states list was not provided"],
     },
 ]
 
 
 INPUT_ADVERSE_COUNTER: List[Dict[str, Any]] = [
-    {"name": "success", "eos_data": [{"totalAdverseDrops": 0}], "side_effect": "", "expected_result": "success", "expected_messages": []},
-    {"name": "failure", "eos_data": [{"totalAdverseDrops": 10}], "side_effect": "", "expected_result": "failure", "expected_messages": []},
+    {
+        "name": "success",
+        "eos_data": [{"totalAdverseDrops": 0}],
+        "side_effect": "",
+        "expected_result": "success", "expected_messages": []
+    },
+    {
+        "name": "failure",
+        "eos_data": [{"totalAdverseDrops": 10}],
+        "side_effect": "",
+        "expected_result": "failure", "expected_messages": ["Device totalAdverseDrops counter is: '10'"]
+    },
 ]

--- a/tests/units/anta_tests/hardware/test_exc.py
+++ b/tests/units/anta_tests/hardware/test_exc.py
@@ -57,6 +57,7 @@ def test_VerifyTemperature(mocked_device: MagicMock, test_data: Any) -> None:
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
 
 
 @pytest.mark.parametrize("test_data", INPUT_TEMPERATURE_TRANSCEIVER, ids=generate_test_ids_list(INPUT_TEMPERATURE_TRANSCEIVER))
@@ -73,6 +74,7 @@ def test_VerifyTransceiversTemperature(mocked_device: MagicMock, test_data: Any)
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
 
 
 @pytest.mark.parametrize("test_data", INPUT_SYSTEM_COOLING, ids=generate_test_ids_list(INPUT_SYSTEM_COOLING))
@@ -89,6 +91,7 @@ def test_VerifyEnvironmentSystemCooling(mocked_device: MagicMock, test_data: Any
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
 
 
 @pytest.mark.parametrize("test_data", INPUT_COOLING, ids=generate_test_ids_list(INPUT_COOLING))
@@ -105,6 +108,7 @@ def test_VerifyEnvironmentCooling(mocked_device: MagicMock, test_data: Any) -> N
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
 
 
 @pytest.mark.parametrize("test_data", INPUT_ENV_POWER, ids=generate_test_ids_list(INPUT_ENV_POWER))
@@ -121,6 +125,7 @@ def test_VerifyEnvironmentPower(mocked_device: MagicMock, test_data: Any) -> Non
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
 
 
 @pytest.mark.parametrize("test_data", INPUT_ADVERSE_COUNTER, ids=generate_test_ids_list(INPUT_ADVERSE_COUNTER))
@@ -137,3 +142,4 @@ def test_VerifyAdverseDrops(mocked_device: MagicMock, test_data: Any) -> None:
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]


### PR DESCRIPTION
`VerifyEnvironmentPower` and `VerifyEnvironmentCooling` tests are now skipped if the accepted_states list if not provided.

This will force users to specify the accepted_states. Will be used in AVD.