### PR TITLE
ci: implement job-selector to speed up CI

### DIFF
--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -7,6 +7,28 @@ on:
   pull_request:
 
 jobs:
+  file-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'anta/*'
+              - 'anta/**'
+              - 'tests/*'
+              - 'tests/**'
+            docs:
+              - '.github/workflows/pull-request-management.yml'
+              - 'mkdocs.yml'
+              - 'docs/*'
+              - 'docs/**'
+              - 'README.md'
   check-requirements:
     runs-on: ubuntu-20.04
     strategy:
@@ -26,6 +48,8 @@ jobs:
   lint-yaml:
     name: Run linting for yaml files
     runs-on: ubuntu-20.04
+    needs: file-changes
+    if: needs.file-changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
@@ -40,6 +64,8 @@ jobs:
   lint-python:
     name: Run isort, black, flake8 and pylint
     runs-on: ubuntu-20.04
+    needs: file-changes
+    if: needs.file-changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -53,6 +79,8 @@ jobs:
   type-python:
     name: Run mypy
     runs-on: ubuntu-20.04
+    needs: file-changes
+    if: needs.file-changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+    needs: file-changes
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -48,7 +49,7 @@ jobs:
   lint-yaml:
     name: Run linting for yaml files
     runs-on: ubuntu-20.04
-    needs: file-changes
+    needs: [file-changes, check-requirements]
     if: needs.file-changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v3

--- a/anta_inventory/inventory-custom_container.yml
+++ b/anta_inventory/inventory-custom_container.yml
@@ -1,2 +1,0 @@
-anta_inventory:
-  hosts: []

--- a/anta_inventory/inventory.yml
+++ b/anta_inventory/inventory.yml
@@ -1,2 +1,0 @@
-anta_inventory:
-  hosts: []

--- a/custom/inventory.yml
+++ b/custom/inventory.yml
@@ -1,2 +1,0 @@
-anta_inventory:
-  hosts: []


### PR DESCRIPTION
Implement job selector based on 2 options:

- code: everything in `anta/` and `tests/`
- doc: everything based on `docs`, `README.md` and `mkdocs.yml`