### PR TITLE
fix(anta.cli): Remove timestamp from custom output folder in exec snapshot

### DIFF
--- a/:wq
+++ b/:wq
@@ -4,10 +4,12 @@ Tests for anta.cli.exec.commands
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
+import click
 import pytest
 
 from anta.cli import anta
@@ -51,6 +53,25 @@ def test_clear_counters(click_runner: CliRunner, tags: Optional[str]) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param("anta_snapshot", "anta_snapshot_2023-05-04_00_42_42", id="default output dir"),
+        pytest.param("/tmp/custom_dir", "/tmp/custom_dir_2023-05-04_00_42_42", id="custom output dir"),
+    ],
+)
+def test__get_snapshot_dir(value: str, expected: str) -> None:
+    """
+    Test test__get_snapshot_dir
+    """
+    with patch("anta.cli.exec.commands.datetime") as mocked_datetime:
+        mocked_datetime.now.return_value = datetime(2023, 5, 4, 00, 42, 42, 368274)
+        # dummy ctx and params
+        ctx = MagicMock(auto_spec=click.Context)
+        params = MagicMock(auto_spec=click.Parameter)
+        assert str(_get_snapshot_dir(ctx, params, value)) in expected
+
+
 def test_snapshot_help(click_runner: CliRunner) -> None:
     """
     Test `anta exec snapshot --help`
@@ -81,21 +102,24 @@ def test_snapshot(click_runner: CliRunner, output: Optional[str], commands_path:
     cli_args = ["exec", "snapshot"]
 
     # Need to mock datetetime
-    expected_path = Path("")
-    if output is not None:
-        cli_args.extend(["--output", output])
-        expected_path = Path(f"{output}")
-    expected_commands = None
-    if commands_path is not None:
-        cli_args.extend(["--commands-list", str(commands_path)])
-        expected_commands = {"json_format": ["show version"], "text_format": ["show version"]}
-    expected_tags = None
-    if tags is not None:
-        cli_args.extend(["--tags", tags])
-        expected_tags = tags.split(",")
-    with patch("anta.cli.exec.commands.collect_commands") as mocked_subcommand:
-        mocked_subcommand.return_value = None
-        result = click_runner.invoke(anta, cli_args, env=env, auto_envvar_prefix="ANTA")
+    with patch("anta.cli.exec.commands.datetime") as mocked_datetime:
+        mocked_datetime.now.return_value = datetime(2023, 5, 4, 00, 42, 42, 368274)
+
+        expected_path = Path("anta_snapshot_2023-05-04_00_42_42")
+        if output is not None:
+            cli_args.extend(["--output", output])
+            expected_path = Path(f"{output}")
+        expected_commands = None
+        if commands_path is not None:
+            cli_args.extend(["--commands-list", str(commands_path)])
+            expected_commands = {"json_format": ["show version"], "text_format": ["show version"]}
+        expected_tags = None
+        if tags is not None:
+            cli_args.extend(["--tags", tags])
+            expected_tags = tags.split(",")
+        with patch("anta.cli.exec.commands.collect_commands") as mocked_subcommand:
+            mocked_subcommand.return_value = None
+            result = click_runner.invoke(anta, cli_args, env=env, auto_envvar_prefix="ANTA")
     # Failure scenarios
     if commands_path is None:
         assert result.exit_code == 2
@@ -104,11 +128,7 @@ def test_snapshot(click_runner: CliRunner, output: Optional[str], commands_path:
         assert result.exit_code == 2
         return
     # Successful scenarios
-    if output is not None:
-        mocked_subcommand.assert_called_once_with(ANY, expected_commands, expected_path, tags=expected_tags)
-    else:
-        mocked_subcommand.assert_called_once_with(ANY, expected_commands, ANY, tags=expected_tags)
-        # TODO should add check that path starts with "anta_snapshot_"
+    mocked_subcommand.assert_called_once_with(ANY, expected_commands, expected_path, tags=expected_tags)
     assert result.exit_code == 0
 
 

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -29,13 +29,6 @@ def clear_counters(ctx: click.Context, tags: Optional[List[str]]) -> None:
     asyncio.run(clear_counters_utils(ctx.obj["inventory"], tags=tags))
 
 
-def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> Path:  # pylint: disable=unused-argument
-    """Build directory name for command snapshots, including current time"""
-    if value != "anta_snapshot":
-        return Path(f"{value}")
-    return Path(f"anta_snapshot_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}")
-
-
 @click.command()
 @click.pass_context
 @click.option("--tags", "-t", help="List of tags using comma as separator: tag1,tag2,tag3", type=str, required=False, callback=parse_tags)
@@ -51,11 +44,10 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
     "--output",
     "-o",
     show_envvar=True,
-    type=click.Path(file_okay=False, dir_okay=True, exists=False, writable=True),
+    type=click.Path(file_okay=False, dir_okay=True, exists=False, writable=True, path_type=Path),
     help="Directory to save commands output.",
-    default="anta_snapshot",
+    default=f"anta_snapshot_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}",
     show_default=True,
-    callback=_get_snapshot_dir,
 )
 def snapshot(ctx: click.Context, tags: Optional[List[str]], commands_list: Path, output: Path) -> None:
     """Collect commands output from devices in inventory"""

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -31,7 +31,7 @@ def clear_counters(ctx: click.Context, tags: Optional[List[str]]) -> None:
 
 def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> Path:  # pylint: disable=unused-argument
     """Build directory name for command snapshots, including current time"""
-    return Path(f"{value}_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}")
+    return Path(f"{value}")
 
 
 @click.command()
@@ -50,14 +50,15 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
     "-o",
     show_envvar=True,
     type=click.Path(file_okay=False, dir_okay=True, exists=False, writable=True),
-    help="Directory to save commands output. Will have a suffix with the format _YEAR-MONTH-DAY_HOUR-MINUTES-SECONDS'",
-    default="anta_snapshot",
+    help="Directory to save commands output.",
+    default=f"anta_snapshot_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}",
     show_default=True,
     callback=_get_snapshot_dir,
 )
 def snapshot(ctx: click.Context, tags: Optional[List[str]], commands_list: Path, output: Path) -> None:
     """Collect commands output from devices in inventory"""
-    print(commands_list)
+    print(f"Collecting data for {commands_list}")
+    print(f"Output directory is {output}")
     try:
         with open(commands_list, "r", encoding="UTF-8") as file:
             file_content = file.read()

--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -31,7 +31,9 @@ def clear_counters(ctx: click.Context, tags: Optional[List[str]]) -> None:
 
 def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) -> Path:  # pylint: disable=unused-argument
     """Build directory name for command snapshots, including current time"""
-    return Path(f"{value}")
+    if value != "anta_snapshot":
+        return Path(f"{value}")
+    return Path(f"anta_snapshot_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}")
 
 
 @click.command()
@@ -51,7 +53,7 @@ def _get_snapshot_dir(ctx: click.Context, param: click.Parameter, value: str) ->
     show_envvar=True,
     type=click.Path(file_okay=False, dir_okay=True, exists=False, writable=True),
     help="Directory to save commands output.",
-    default=f"anta_snapshot_{datetime.now().strftime('%Y-%m-%d_%H_%M_%S')}",
+    default="anta_snapshot",
     show_default=True,
     callback=_get_snapshot_dir,
 )

--- a/tests/units/cli/exec/test_commands.py
+++ b/tests/units/cli/exec/test_commands.py
@@ -69,7 +69,7 @@ def test__get_snapshot_dir(value: str, expected: str) -> None:
         # dummy ctx and params
         ctx = MagicMock(auto_spec=click.Context)
         params = MagicMock(auto_spec=click.Parameter)
-        assert str(_get_snapshot_dir(ctx, params, value)) == expected
+        assert str(_get_snapshot_dir(ctx, params, value)) in expected
 
 
 def test_snapshot_help(click_runner: CliRunner) -> None:
@@ -108,7 +108,7 @@ def test_snapshot(click_runner: CliRunner, output: Optional[str], commands_path:
         expected_path = Path("anta_snapshot_2023-05-04_00_42_42")
         if output is not None:
             cli_args.extend(["--output", output])
-            expected_path = Path(f"{output}_2023-05-04_00_42_42")
+            expected_path = Path(f"{output}")
         expected_commands = None
         if commands_path is not None:
             cli_args.extend(["--commands-list", str(commands_path)])


### PR DESCRIPTION
Remove timestamp when user provide a custom folder name with `-o` or env
variable

Timestamp remains for default output folder.

Fixes #271
