### PR TITLE
fix(anta): Remove paswsord field in get inventory and debug

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -180,8 +180,7 @@ class AsyncEOSDevice(AntaDevice):
         https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
         """
 
-        def hide_password(password: str) -> str:
-            return "*" * len(password)
+        PASSWORD_VALUE = "<removed>"
 
         yield from super().__rich_repr__()
         yield "host", self._session.host
@@ -191,8 +190,8 @@ class AsyncEOSDevice(AntaDevice):
         yield "insecure", self._ssh_opts.known_hosts is None
         if __DEBUG__:
             _ssh_opts = vars(self._ssh_opts).copy()
-            _ssh_opts["password"] = hide_password(_ssh_opts["password"])
-            _ssh_opts["kwargs"]["password"] = hide_password(_ssh_opts["kwargs"]["password"])
+            _ssh_opts["password"] = PASSWORD_VALUE
+            _ssh_opts["kwargs"]["password"] = PASSWORD_VALUE
             yield "_session", vars(self._session)
             yield "_ssh_opts", _ssh_opts
 

--- a/anta/device.py
+++ b/anta/device.py
@@ -183,9 +183,7 @@ class AsyncEOSDevice(AntaDevice):
         yield "host", self._session.host
         yield "eapi_port", self._session.port
         yield "username", self._ssh_opts.username
-        yield "password", self._ssh_opts.password
         yield "enable", self.enable
-        yield "enable_password", self._enable_password
         yield "insecure", self._ssh_opts.known_hosts is None
         if __DEBUG__:
             yield "_session", vars(self._session)

--- a/anta/device.py
+++ b/anta/device.py
@@ -179,6 +179,10 @@ class AsyncEOSDevice(AntaDevice):
         Implements Rich Repr Protocol
         https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol
         """
+
+        def hide_password(password: str) -> str:
+            return "*" * len(password)
+
         yield from super().__rich_repr__()
         yield "host", self._session.host
         yield "eapi_port", self._session.port
@@ -186,8 +190,11 @@ class AsyncEOSDevice(AntaDevice):
         yield "enable", self.enable
         yield "insecure", self._ssh_opts.known_hosts is None
         if __DEBUG__:
+            _ssh_opts = vars(self._ssh_opts).copy()
+            _ssh_opts["password"] = hide_password(_ssh_opts["password"])
+            _ssh_opts["kwargs"]["password"] = hide_password(_ssh_opts["kwargs"]["password"])
             yield "_session", vars(self._session)
-            yield "_ssh_opts", vars(self._ssh_opts)
+            yield "_ssh_opts", _ssh_opts
 
     def __eq__(self, other: object) -> bool:
         """


### PR DESCRIPTION
Get inventory update:

```
❯ anta get inventory
Current inventory content is:
{
    'spine01': AsyncEOSDevice(
        name='spine01',
        tags=['fabric', 'spine', 'all'],
        hw_model=None,
        is_online=False,
        established=False,
        host='192.168.0.10',
        eapi_port=443,
        username='ansible',
        enable=False,
        insecure=False
    )
}
```

Passwords have been hidden in data structures shown in ANTA DEBUG mode:
```
ANTA_DEBUG=true anta get inventory
{
    'spine1': AsyncEOSDevice(
        name='spine1',
        tags=['clab', 'spine', 'all'],
        hw_model=None,
        is_online=False,
        established=False,
        host='clab-evpn-vxlan-fabric-spine1',
        eapi_port=443,
        username='admin',
        enable=True,
        insecure=True,
        _session={
            'port': 443,
            'host': 'clab-evpn-vxlan-fabric-spine1',
            'auth': <httpx.BasicAuth object at 0x7fcb10fcba30>,
            '_base_url': URL('https://clab-evpn-vxlan-fabric-spine1'),
            '_auth': <httpx.BasicAuth object at 0x7fcb10fcba30>,
            '_params': QueryParams(''),
            '_headers': Headers({'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'python-httpx/0.23.3', 'content-type':
'application/json-rpc'}),
            '_cookies': <Cookies[]>,
            '_timeout': Timeout(timeout=500),
            'follow_redirects': False,
            'max_redirects': 20,
            '_event_hooks': {'request': [], 'response': []},
            '_trust_env': True,
            '_default_encoding': 'utf-8',
            '_netrc': <httpx._utils.NetRCInfo object at 0x7fcb10fe6d00>,
            '_state': <ClientState.UNOPENED: 1>,
            '_transport': <httpx.AsyncHTTPTransport object at 0x7fcb10fe6ee0>,
            '_mounts': {}
        },
        _ssh_opts={
            'kwargs': {
                'last_config': None,
                'host': 'clab-evpn-vxlan-fabric-spine1',
                'port': 22,
                'username': 'admin',
                'password': '<removed>,
                'known_hosts': None
            },
      
            <truncated>

            'username': 'admin',
            'password': '<removed>',
            
            <truncated>
        }
    )
}
```