### PR TITLE
feat: prompt passwords from stdin if not provided via CLI options

### DIFF
--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -15,7 +15,7 @@ from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
 from anta.cli.nrfu import commands as check_commands
-from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, prompt_password, prompt_enable_password, setup_logging
+from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, prompt_enable_password, prompt_password, setup_logging
 from anta.result_manager.models import TestResult
 
 
@@ -29,12 +29,7 @@ from anta.result_manager.models import TestResult
     help="Username to connect to EOS",
     required=True,
 )
-@click.option(
-    "--password",
-    show_envvar=True,
-    help="Password to connect to EOS",
-    callback=prompt_password
-)
+@click.option("--password", show_envvar=True, help="Password to connect to EOS", callback=prompt_password)
 @click.option(
     "--enable",
     show_envvar=True,

--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -15,7 +15,7 @@ from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
 from anta.cli.nrfu import commands as check_commands
-from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, prompt_enable_password, setup_logging
+from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, prompt_password, prompt_enable_password, setup_logging
 from anta.result_manager.models import TestResult
 
 
@@ -29,11 +29,11 @@ from anta.result_manager.models import TestResult
     help="Username to connect to EOS",
     required=True,
 )
-@click.password_option(
+@click.option(
     "--password",
     show_envvar=True,
     help="Password to connect to EOS",
-    prompt="Please enter a password to connect to EOS",
+    callback=prompt_password
 )
 @click.option(
     "--enable",

--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -15,7 +15,7 @@ from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
 from anta.cli.nrfu import commands as check_commands
-from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, requires_enable, setup_logging
+from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory, prompt_enable_password, setup_logging
 from anta.result_manager.models import TestResult
 
 
@@ -29,11 +29,25 @@ from anta.result_manager.models import TestResult
     help="Username to connect to EOS",
     required=True,
 )
-@click.option(
+@click.password_option(
     "--password",
     show_envvar=True,
     help="Password to connect to EOS",
-    required=True,
+    prompt="Please enter a password to connect to EOS",
+)
+@click.option(
+    "--enable",
+    show_envvar=True,
+    is_flag=True,
+    default=False,
+    help="Some commands may require EOS Privileged EXEC mode. This option tries to access this mode before sending a command to the device.",
+    show_default=True,
+)
+@click.option(
+    "--enable-password",
+    show_envvar=True,
+    help="If a password is required to access EOS Privileged EXEC mode, it must be provided. --enable must be set.",
+    callback=prompt_enable_password,
 )
 @click.option(
     "--timeout",
@@ -49,20 +63,6 @@ from anta.result_manager.models import TestResult
     default=False,
     help="Disable SSH Host Key validation",
     show_default=True,
-)
-@click.option(
-    "--enable",
-    show_envvar=True,
-    is_flag=True,
-    default=False,
-    help="Add enable mode towards the devices if required to connect",
-    show_default=True,
-)
-@click.option(
-    "--enable-password",
-    show_envvar=True,
-    help="Enable password if required to connect, --enable MUST be set",
-    callback=requires_enable,
 )
 @click.option(
     "--inventory",

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -80,7 +80,6 @@ def parse_tags(ctx: click.Context, param: Option, value: str) -> Optional[List[s
 
 
 def prompt_enable_password(ctx: click.Context, param: Option, value: Optional[str]) -> Optional[str]:
-    # pylint: disable=unused-argument
     """
     Click option callback to ensure that enable is True when the option is set
     """
@@ -88,8 +87,7 @@ def prompt_enable_password(ctx: click.Context, param: Option, value: Optional[st
         raise click.BadParameter(f"'{param.opts[0]}' requires '--enable'")
     if value is None and ctx.params.get("enable") is True:
         return click.prompt("Please enter a password to enter EOS privileged EXEC mode", type=str, hide_input=True, confirmation_prompt=True)
-    else:
-        return value
+    return value
 
 
 def parse_catalog(ctx: click.Context, param: Option, value: str) -> List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]:

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -79,10 +79,28 @@ def parse_tags(ctx: click.Context, param: Option, value: str) -> Optional[List[s
     return None
 
 
+def prompt_password(ctx: click.Context, param: Option, value: Optional[str]) -> Optional[str]:
+    # pylint: disable=unused-argument
+    """
+    Click option callback to ensure that enable is True when the option is set
+    """
+    if ctx.obj.get("_anta_help"):
+        # Currently looking for help for a subcommand so no
+        # need to prompt the password
+        return None
+    if value is None:
+        return click.prompt("Please enter a password to connect to EOS", type=str, hide_input=True, confirmation_prompt=True)
+    return value
+
+
 def prompt_enable_password(ctx: click.Context, param: Option, value: Optional[str]) -> Optional[str]:
     """
     Click option callback to ensure that enable is True when the option is set
     """
+    if ctx.obj.get("_anta_help"):
+        # Currently looking for help for a subcommand so no
+        # need to prompt the password
+        return None
     if value is not None and ctx.params.get("enable") is not True:
         raise click.BadParameter(f"'{param.opts[0]}' requires '--enable'")
     if value is None and ctx.params.get("enable") is True:

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -79,14 +79,17 @@ def parse_tags(ctx: click.Context, param: Option, value: str) -> Optional[List[s
     return None
 
 
-def requires_enable(ctx: click.Context, param: Option, value: Optional[str]) -> Optional[str]:
+def prompt_enable_password(ctx: click.Context, param: Option, value: Optional[str]) -> Optional[str]:
     # pylint: disable=unused-argument
     """
     Click option callback to ensure that enable is True when the option is set
     """
     if value is not None and ctx.params.get("enable") is not True:
-        raise click.BadParameter(f"'{param.opts[0]}' requires '--enable' (or setting associated env variable)")
-    return value
+        raise click.BadParameter(f"'{param.opts[0]}' requires '--enable'")
+    if value is None and ctx.params.get("enable") is True:
+        return click.prompt("Please enter a password to enter EOS privileged EXEC mode", type=str, hide_input=True, confirmation_prompt=True)
+    else:
+        return value
 
 
 def parse_catalog(ctx: click.Context, param: Option, value: str) -> List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]:

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,16 +34,19 @@ Options:
   --username TEXT                 Username to connect to EOS  [env var:
                                   ANTA_USERNAME; required]
   --password TEXT                 Password to connect to EOS  [env var:
-                                  ANTA_PASSWORD; required]
+                                  ANTA_PASSWORD]
+  --enable                        Some commands may require EOS Privileged
+                                  EXEC mode. This option tries to access this
+                                  mode before sending a command to the device.
+                                  [env var: ANTA_ENABLE]
+  --enable-password TEXT          If a password is required to access EOS
+                                  Privileged EXEC mode, it must be provided.
+                                  --enable must be set.  [env var:
+                                  ANTA_ENABLE_PASSWORD]
   --timeout INTEGER               Global connection timeout  [env var:
                                   ANTA_TIMEOUT; default: 5]
   --insecure                      Disable SSH Host Key validation  [env var:
                                   ANTA_INSECURE]
-  --enable                        Add enable mode towards the devices if
-                                  required to connect  [env var: ANTA_ENABLE]
-  --enable-password TEXT          Enable password if required to connect,
-                                  --enable MUST be set  [env var:
-                                  ANTA_ENABLE_PASSWORD]
   -i, --inventory FILE            Path to the inventory YAML file  [env var:
                                   ANTA_INVENTORY; required]
   --log-level, --log [CRITICAL|ERROR|WARNING|INFO|DEBUG]

--- a/docs/snippets/anta_help.txt
+++ b/docs/snippets/anta_help.txt
@@ -7,16 +7,19 @@ Options:
   --username TEXT                 Username to connect to EOS  [env var:
                                   ANTA_USERNAME; required]
   --password TEXT                 Password to connect to EOS  [env var:
-                                  ANTA_PASSWORD; required]
+                                  ANTA_PASSWORD]
+  --enable                        Some commands may require EOS Privileged
+                                  EXEC mode. This option tries to access this
+                                  mode before sending a command to the device.
+                                  [env var: ANTA_ENABLE]
+  --enable-password TEXT          If a password is required to access EOS
+                                  Privileged EXEC mode, it must be provided.
+                                  --enable must be set.  [env var:
+                                  ANTA_ENABLE_PASSWORD]
   --timeout INTEGER               Global connection timeout  [env var:
                                   ANTA_TIMEOUT; default: 5]
   --insecure                      Disable SSH Host Key validation  [env var:
                                   ANTA_INSECURE]
-  --enable                        Add enable mode towards the devices if
-                                  required to connect  [env var: ANTA_ENABLE]
-  --enable-password TEXT          Enable password if required to connect,
-                                  --enable MUST be set  [env var:
-                                  ANTA_ENABLE_PASSWORD]
   -i, --inventory FILE            Path to the inventory YAML file  [env var:
                                   ANTA_INVENTORY; required]
   --log-level, --log [CRITICAL|ERROR|WARNING|INFO|DEBUG]


### PR DESCRIPTION
Use click [password_option](https://click.palletsprojects.com/en/8.1.x/api/#click.password_option) and [prompt](https://click.palletsprojects.com/en/8.1.x/api/#click.prompt) to prompt EOS passwords if not provided via environment variables or CLI options.
This is to provide a more secure way to provide passwords without using environment variables.