### PR TITLE
fix(anta.tests)!: Update VerifySyslog

### DIFF
--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -288,3 +288,30 @@ class VerifyLoggingAccounting(AntaTest):
             self.result.is_success()
         else:
             self.result.is_failure("AAA accounting logs are not generated")
+
+
+class VerifyLoggingErrors(AntaTest):
+    """
+    This test verifies there are no syslog messages with a severity of ERRORS or higher.
+
+    Expected Results:
+      * success: The test will pass if there are NO syslog messages with a severity of ERRORS or higher.
+      * failure: The test will fail if ERRORS or higher syslog messages are present.
+    """
+
+    name = "VerifyLoggingWarning"
+    description = "This test verifies there are no syslog messages with a severity of ERRORS or higher."
+    categories = ["logging"]
+    commands = [AntaCommand(command="show logging threshold errors", ofmt="text")]
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """
+        Run VerifyLoggingWarning validation
+        """
+        command_output = self.instance_commands[0].text_output
+
+        if len(command_output) == 0:
+            self.result.is_success()
+        else:
+            self.result.is_failure("Device has reported syslog messages with a severity of ERRORS or higher")

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -152,33 +152,6 @@ class VerifyAgentLogs(AntaTest):
             self.result.is_failure(f"Device has reported agent crashes:\n * {agents}")
 
 
-class VerifySyslog(AntaTest):
-    """
-    This test verifies there are no syslog messages with a severity of WARNING or higher in the last 7 days.
-
-    Expected Results:
-      * success: The test will pass if there are NO syslog messages with a severity of WARNING or higher in the last 7 days.
-      * failure: The test will fail if WARNING or higher syslog messages are present in the last 7 days.
-    """
-
-    name = "VerifySyslog"
-    description = "This test verifies there are no syslog messages with a severity of WARNING or higher in the last 7 days."
-    categories = ["system"]
-    commands = [AntaCommand(command="show logging last 7 days threshold warnings", ofmt="text")]
-
-    @AntaTest.anta_test
-    def test(self) -> None:
-        """
-        Run VerifySyslog validation
-        """
-        command_output = self.instance_commands[0].text_output
-
-        if len(command_output) == 0:
-            self.result.is_success()
-        else:
-            self.result.is_failure("Device has reported some log messages with WARNING or higher severity")
-
-
 class VerifyCPUUtilization(AntaTest):
     """
     This test verifies whether the CPU utilization is below 75%.

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -128,6 +128,7 @@ anta.tests.logging:
   - VerifyLoggingHostname:
   - VerifyLoggingTimestamp:
   - VerifyLoggingAccounting:
+  - VerifyLoggingErrors:
 
 anta.tests.mlag:
   - VerifyMlagStatus:
@@ -221,7 +222,6 @@ anta.tests.system:
   - VerifyReloadCause:
   - VerifyCoredump:
   - VerifyAgentLogs:
-  - VerifySyslog:
   - VerifyCPUUtilization:
   - VerifyMemoryUtilization:
   - VerifyFileSystemUtilization:

--- a/tests/units/anta_tests/logging/data.py
+++ b/tests/units/anta_tests/logging/data.py
@@ -280,3 +280,23 @@ INPUT_LOGGING_ACCOUNTING: List[Dict[str, Any]] = [
         "expected_messages": ["AAA accounting logs are not generated"]
     },
 ]
+
+
+INPUT_LOGGING_ERRORS: List[Dict[str, Any]] = [
+    {
+        "name": "success",
+        "eos_data": [""],
+        "side_effect": [],
+        "expected_result": "success",
+        "expected_messages": [],
+    },
+    {
+        "name": "failure",
+        "eos_data": [
+          "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag (pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)"
+        ],
+        "side_effect": [],
+        "expected_result": "failure",
+        "expected_messages": ["Device has reported syslog messages with a severity of ERRORS or higher"],
+    },
+]

--- a/tests/units/anta_tests/logging/test_exc.py
+++ b/tests/units/anta_tests/logging/test_exc.py
@@ -12,6 +12,7 @@ import pytest
 
 from anta.tests.logging import (
     VerifyLoggingAccounting,
+    VerifyLoggingErrors,
     VerifyLoggingHostname,
     VerifyLoggingHosts,
     VerifyLoggingLogsGeneration,
@@ -23,6 +24,7 @@ from tests.lib.utils import generate_test_ids_list
 
 from .data import (
     INPUT_LOGGING_ACCOUNTING,
+    INPUT_LOGGING_ERRORS,
     INPUT_LOGGING_HOSTNAME,
     INPUT_LOGGING_HOSTS,
     INPUT_LOGGING_LOGS_GEN,
@@ -145,6 +147,23 @@ def test_VerifyLoggingAccounting(mocked_device: MagicMock, test_data: Any) -> No
     asyncio.run(test.test())
 
     logging.info(f"Test result is: {test.result}")
+
+    assert str(test.result.name) == mocked_device.name
+    assert test.result.result == test_data["expected_result"]
+    assert test.result.messages == test_data["expected_messages"]
+
+
+@pytest.mark.parametrize("test_data", INPUT_LOGGING_ERRORS, ids=generate_test_ids_list(INPUT_LOGGING_ERRORS))
+def test_VerifyLoggingErrors(mocked_device: MagicMock, test_data: Any) -> None:
+    """Check VerifyLoggingErrors."""
+
+    logging.info(f"Mocked device is: {mocked_device.host}")
+    logging.info(f"Mocked HW is: {mocked_device.hw_model}")
+
+    test = VerifyLoggingErrors(mocked_device, eos_data=test_data["eos_data"])
+    asyncio.run(test.test())
+
+    logging.debug(f"test result is: {test.result}")
 
     assert str(test.result.name) == mocked_device.name
     assert test.result.result == test_data["expected_result"]

--- a/tests/units/anta_tests/system/data.py
+++ b/tests/units/anta_tests/system/data.py
@@ -159,26 +159,6 @@ EntityManager::doBackoff waiting for remote sysdb version ...................ok
     },
 ]
 
-INPUT_SYSLOG: List[Dict[str, Any]] = [
-    {
-        "name": "success",
-        "eos_data": [""],
-        "side_effect": [],
-        "expected_result": "success",
-        "expected_messages": [],
-    },
-    {
-        "name": "failure",
-        "eos_data": [
-            """May  4 10:23:59 Leaf1 Lldp: %LLDP-3-NEIGHBOR_NEW: LLDP neighbor with chassisId 5022.0057.d059 and portId "Ethernet1" added on interface
-Ethernet1
-"""
-        ],
-        "side_effect": [],
-        "expected_result": "failure",
-        "expected_messages": ["Device has reported some log messages with WARNING or higher severity"],
-    },
-]
 
 INPUT_CPU_UTILIZATION: List[Dict[str, Any]] = [
     {

--- a/tests/units/anta_tests/system/test_exc.py
+++ b/tests/units/anta_tests/system/test_exc.py
@@ -18,7 +18,6 @@ from anta.tests.system import (
     VerifyMemoryUtilization,
     VerifyNTP,
     VerifyReloadCause,
-    VerifySyslog,
     VerifyUptime,
 )
 from tests.lib.utils import generate_test_ids_list
@@ -31,7 +30,6 @@ from .data import (
     INPUT_MEMORY_UTILIZATION,
     INPUT_NTP,
     INPUT_RELOAD_CAUSE,
-    INPUT_SYSLOG,
     INPUT_UPTIME,
 )
 
@@ -95,23 +93,6 @@ def test_VerifyAgentLogs(mocked_device: MagicMock, test_data: Any) -> None:
     logging.info(f"Mocked HW is: {mocked_device.hw_model}")
 
     test = VerifyAgentLogs(mocked_device, eos_data=test_data["eos_data"])
-    asyncio.run(test.test())
-
-    logging.debug(f"test result is: {test.result}")
-
-    assert str(test.result.name) == mocked_device.name
-    assert test.result.result == test_data["expected_result"]
-    assert test.result.messages == test_data["expected_messages"]
-
-
-@pytest.mark.parametrize("test_data", INPUT_SYSLOG, ids=generate_test_ids_list(INPUT_SYSLOG))
-def test_VerifySyslog(mocked_device: MagicMock, test_data: Any) -> None:
-    """Check VerifySyslog."""
-
-    logging.info(f"Mocked device is: {mocked_device.host}")
-    logging.info(f"Mocked HW is: {mocked_device.hw_model}")
-
-    test = VerifySyslog(mocked_device, eos_data=test_data["eos_data"])
     asyncio.run(test.test())
 
     logging.debug(f"test result is: {test.result}")


### PR DESCRIPTION
Move anta.tests.system.VerifySyslog test to anta.tests.logging.VerifyLoggingErrors.

For now, the test has been modified to verify syslog messages with a severity of ERRORS or higher instead of WARNING.

The last 7 days has been removed as well to optimize test performance on devices with large log buffers.

This test can be revisited in the future once we implement caching in #342.

Fixes: #332 

