### PR TITLE
feat(anta.cli): Enable CLI command auto aliases

### DIFF
--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -18,7 +18,7 @@ from anta.cli.debug import commands as debug_commands
 from anta.cli.exec import commands as exec_commands
 from anta.cli.get import commands as get_commands
 from anta.cli.nrfu import commands as check_commands
-from anta.cli.utils import IgnoreRequiredWithHelp, parse_catalog, parse_inventory
+from anta.cli.utils import AliasedGroup, IgnoreRequiredWithHelp, parse_catalog, parse_inventory
 from anta.loader import setup_logging
 from anta.result_manager import ResultManager
 from anta.result_manager.models import TestResult
@@ -151,17 +151,17 @@ def nrfu(ctx: click.Context, catalog: List[Tuple[Callable[..., TestResult], Dict
     ctx.obj["result_manager"] = ResultManager()
 
 
-@anta.group("exec")
+@anta.group("exec", cls=AliasedGroup)
 def _exec() -> None:
     """Execute commands to inventory devices"""
 
 
-@anta.group("get")
+@anta.group("get", cls=AliasedGroup)
 def _get() -> None:
     """Get data from/to ANTA"""
 
 
-@anta.group("debug")
+@anta.group("debug", cls=AliasedGroup)
 def _debug() -> None:
     """Debug commands for building ANTA"""
 

--- a/anta/cli/utils.py
+++ b/anta/cli/utils.py
@@ -164,3 +164,49 @@ class IgnoreRequiredWithHelp(click.Group):
                 param.required = False
 
             return super().parse_args(ctx, args)
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Any:
+        """Todo: document code"""
+        rv = click.Group.get_command(self, ctx, cmd_name)
+        if rv is not None:
+            return rv
+        matches = [x for x in self.list_commands(ctx) if x.startswith(cmd_name)]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return click.Group.get_command(self, ctx, matches[0])
+        ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+        return None
+
+    def resolve_command(self, ctx: click.Context, args: Any) -> Any:
+        """Todo: document code"""
+        # always return the full command name
+        _, cmd, args = super().resolve_command(ctx, args)
+        return cmd.name, cmd, args  # type: ignore
+
+
+class AliasedGroup(click.Group):
+    """
+    Implements a subclass of Group that accepts a prefix for a command.
+    If there were a command called push, it would accept pus as an alias (so long as it was unique)
+    From Click documentation
+    """
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Any:
+        """Todo: document code"""
+        rv = click.Group.get_command(self, ctx, cmd_name)
+        if rv is not None:
+            return rv
+        matches = [x for x in self.list_commands(ctx) if x.startswith(cmd_name)]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return click.Group.get_command(self, ctx, matches[0])
+        ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+        return None
+
+    def resolve_command(self, ctx: click.Context, args: Any) -> Any:
+        """Todo: document code"""
+        # always return the full command name
+        _, cmd, args = super().resolve_command(ctx, args)
+        return cmd.name, cmd, args  # type: ignore


### PR DESCRIPTION
Add support for auto aliases in CLI to detect commands with CLI shortcut

So user can type short string instead of full keywords until they are unique.
Below is an example

> **warning**
> It is not applicable to options and arguments

```bash
# Original CLI
❯ anta nrfu -c .personal/catalog-class.yml table --group-by device

# With aliases in CLI
❯ anta nr -c .personal/catalog-class.yml tab --group-by device
╭────────────────────── Settings ──────────────────────╮
│ Running ANTA tests:                                  │
│ - ANTA Inventory contains 6 devices (AsyncEOSDevice) │
│ - Tests catalog contains 4 tests                     │
╰──────────────────────────────────────────────────────╯
```
