### PR TITLE
chore: Add rewrite back to generic test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 if TYPE_CHECKING:
     from pytest import Metafunc
 
@@ -16,6 +18,10 @@ if TYPE_CHECKING:
 pytest_plugins = [
     "tests.lib.fixture",
 ]
+
+# Enable nice assert messages
+# https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("tests.lib.anta")
 
 # Placeholder to disable logging of some external libs
 for _ in ("asyncio", "httpx"):


### PR DESCRIPTION
Fixes #385 

Because of the voodoo magic from @mtache  we need to tell pytest to rewrite the asserts on `tests.lib.anta` when it is imported.

Tested manually:
* modify one test to make it fail - check that the assertion message is comprehensive
* comment the line in conftest and run again - check that you get only `Assertion Error`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
