### PR TITLE
feat(anta.tests)!: Implement caching

### DIFF
--- a/anta/models.py
+++ b/anta/models.py
@@ -6,6 +6,7 @@ Models to define a TestStructure
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -87,8 +88,9 @@ class AntaCommand(BaseModel):
         version: eAPI version - valid values are 1 or "latest" - default is "latest"
         revision: eAPI revision of the command. Valid values are 1 to 99. Revision has precedence over version.
         ofmt: eAPI output - json or text - default is json
+        output: Output of the command
         template: AntaTemplate object used to render this command
-        params: dictionary of variables with string values to render the template
+        params: Dictionary of variables with string values to render the template
         failed: If the command execution fails, the Exception object is stored in this field
     """
 
@@ -103,6 +105,12 @@ class AntaCommand(BaseModel):
     template: Optional[AntaTemplate] = None
     failed: Optional[Exception] = None
     params: Optional[Dict[str, Any]] = None
+
+    @property
+    def uid(self) -> str:
+        """Generate a unique identifier for this command"""
+        uid_str = f"{self.command}_{self.version}_{self.revision or 'NA'}_{self.ofmt}"
+        return hashlib.md5(uid_str.encode()).hexdigest()
 
     @property
     def json_output(self) -> dict[str, Any]:

--- a/anta/models.py
+++ b/anta/models.py
@@ -88,7 +88,7 @@ class AntaCommand(BaseModel):
         version: eAPI version - valid values are 1 or "latest" - default is "latest"
         revision: eAPI revision of the command. Valid values are 1 to 99. Revision has precedence over version.
         ofmt: eAPI output - json or text - default is json
-        output: Output of the command
+        output: Output of the command populated by the collect() function
         template: AntaTemplate object used to render this command
         params: Dictionary of variables with string values to render the template
         failed: If the command execution fails, the Exception object is stored in this field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ maintainers = [
 description = "Arista Network Test Automation (ANTA) Framework"
 license = { file = "LICENSE" }
 dependencies = [
+  "aiocache~=0.12.2"
   "aio-eapi==0.6.3",
   "click~=8.1.6",
   "click-help-colors~=0.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 description = "Arista Network Test Automation (ANTA) Framework"
 license = { file = "LICENSE" }
 dependencies = [
-  "aiocache~=0.12.2"
+  "aiocache~=0.12.2",
   "aio-eapi==0.6.3",
   "click~=8.1.6",
   "click-help-colors~=0.9",


### PR DESCRIPTION
# Description

Implement caching with `aiocache` library. 

Cache key design:

`<device_name>:<uid>`

The `uid` is a new property attribute  of `AntaCommand`, which is a UID generated from the command, version, revision and output format.

Caching is implemented in the `AntaDevice.collect_commands` async function where the inner `collect_command` function first checks if the `command.uid` is present in the cache and if it is, `command.output` will be populate by the cache. If not, the `collect()` function will be run as usual and the output will be saved in the cache.

Fixes #342 

# Tasks:
- [ ] Add a knob in AntaTest to activate/deactivate caching for a specific test
- [ ] Add logging with `aiocache` plugins for cache hit ratio, etc.
- [ ] Implement `click` CLI options to tweak caching (TTL, etc.)
- [ ] Maybe need to add a coroutine to check and clean-up unused Locks.
- [ ] Add functionalities to support external backend caches like Redis/memcached - future PR maybe.
- [ ] Documentation + examples

Caveats:
- Some tests in ANTA will break with caching. Logging tests are a good example where we generate a log message and check for that log right after. That's why we need a way to activate/deactivate caching for specific tests.
- Since there is a lot of varied UIDs and each device has its own instance of the `AntaDevice` class, we might need a lock cleanup strategy to optimize performance when running thousands of tests.

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
