### PR TITLE
feat(anta): Add support for command blacklist to secure tests

### DIFF
--- a/anta/models.py
+++ b/anta/models.py
@@ -397,7 +397,7 @@ class AntaTest(ABC):
     def blocked(self) -> bool:
         """Check if CLI commands contain a blocked keyword."""
         state = False
-        for command in self.commands:
+        for command in self.instance_commands:
             for pattern in BLACKLIST_REGEX:
                 if re.match(pattern, command.command):
                     self.logger.error(f"Command <{command.command}> is blocked for security reason matching {BLACKLIST_REGEX}")

--- a/anta/models.py
+++ b/anta/models.py
@@ -34,6 +34,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 DEFAULT_TAG = "all"
 
+# TODO - make this configurable - with an env var maybe?
 BLACKLIST_REGEX = [r"^reload.*", r"^conf\w*\s*(terminal|session)*", r"^wr\w*\s*\w+"]
 
 logger = logging.getLogger(__name__)

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -21,6 +21,9 @@
 ![](../imgs/uml/anta.models.AntaCommand.jpeg)
 ### ::: anta.models.AntaCommand
 
+!!! warning
+    CLI commands are protected to avoid execution of critical commands such as `reload` or `write erase`.
+
 # Template definition
 
 ## UML Diagram

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -24,6 +24,10 @@
 !!! warning
     CLI commands are protected to avoid execution of critical commands such as `reload` or `write erase`.
 
+      - Reload command: `^reload\s*\w*`
+      - Configure mode: `^conf\w*\s*(terminal|session)*`
+      - Write: `^wr\w*\s*\w+`
+
 # Template definition
 
 ## UML Diagram

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -266,3 +266,29 @@ class Test_AntaTest:
         # Test that the test() code works as expected
         if "message" in data["expected"]["test"]:
             assert data["expected"]["test"]["message"] in test.result.messages
+
+
+ANTATEST_BLACKLIST_DATA = ["reload", "reload --force", "write", "wr mem"]
+
+
+@pytest.mark.parametrize("data", ANTATEST_BLACKLIST_DATA)
+def test_blacklist(mocked_device: MagicMock, data: str) -> None:
+    """Test for blacklisting function."""
+
+    class FakeTestWithBlacklist(AntaTest):
+        """Fake Test for blacklist"""
+
+        name = "FakeTestWithBlacklist"
+        description = "ANTA test that has blacklisted command"
+        categories = []
+        commands = [AntaCommand(command=data)]
+
+        @AntaTest.anta_test
+        def test(self) -> None:
+            self.result.is_success()
+
+    test_instance = FakeTestWithBlacklist(mocked_device, inputs=None)
+
+    # Run the test() method
+    asyncio.run(test_instance.test())
+    assert test_instance.result.result == "error"


### PR DESCRIPTION
# Description

<!-- PR description !-->

Add support of a list of blacklisted regex to secure test execution and avoid
any critical change on devices.

It currently blocked CLI with following regex

- Reload command: `^reload\s*\w*`
- Configure mode: `^conf\w*\s*(terminal|session)*`
- Write: `^wr\w*\s*\w+`

Fixes #413 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
