### PR TITLE
Test: Typo in example catalog for test name

### DIFF
--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -298,7 +298,7 @@ anta.tests.routing:
           - afi: "ipv6"
             safi: "unicast"
             vrf: "DEV"
-    - VerifyBGPSpecificPeer:
+    - VerifyBGPSpecificPeers:
         address_families:
           - afi: "evpn"
             peers:


### PR DESCRIPTION
# Description

Current `examples/tests.yaml` is failing 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
