### PR TITLE
fix(anta.tests): Fix VerifyLLDPNeighbors

### DIFF
--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -23,7 +23,7 @@ class VerifyReachability(AntaTest):
     """
     Test network reachability to one or many destination IP(s).
 
-    Expected failures:
+    Expected Results:
         * success: The test will pass if all destination IP(s) are reachable.
         * failure: The test will fail if one or many destination IP(s) are unreachable.
     """
@@ -76,7 +76,7 @@ class VerifyLLDPNeighbors(AntaTest):
     """
     This test verifies that the provided LLDP neighbors are present and connected with the correct configuration.
 
-    Expected failures:
+    Expected Results:
         * success: The test will pass if each of the provided LLDP neighbors is present and connected to the specified port and device.
         * failure: The test will fail if any of the following conditions are met:
             - The provided LLDP neighbor is not found.

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -216,6 +216,38 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "failure-port-not-configured",
+        "test": VerifyLLDPNeighbors,
+        "inputs": {
+            "neighbors": [
+                {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
+                {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
+            ]
+        },
+        "eos_data": [
+            {
+                "lldpNeighbors": {
+                    "Ethernet1": {
+                        "lldpNeighborInfo": [
+                            {
+                                "chassisIdType": "macAddress",
+                                "chassisId": "001c.73a0.fc18",
+                                "systemName": "DC1-SPINE1",
+                                "neighborInterfaceInfo": {
+                                    "interfaceIdType": "interfaceName",
+                                    "interfaceId": '"Ethernet1"',
+                                    "interfaceId_v2": "Ethernet1",
+                                    "interfaceDescription": "P2P_LINK_TO_DC1-LEAF1A_Ethernet1",
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        ],
+        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'port_not_configured': ['Ethernet2']}"]},
+    },
+    {
         "name": "failure-no-neighbor",
         "test": VerifyLLDPNeighbors,
         "inputs": {
@@ -246,7 +278,7 @@ DATA: list[dict[str, Any]] = [
                 }
             }
         ],
-        "expected": {"result": "failure", "messages": ["The following port(s) have no LLDP neighbor: ['Ethernet2']"]},
+        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'no_lldp_neighbor': ['Ethernet2']}"]},
     },
     {
         "name": "failure-wrong-neighbor",
@@ -293,15 +325,16 @@ DATA: list[dict[str, Any]] = [
                 }
             }
         ],
-        "expected": {"result": "failure", "messages": ["The following port(s) have the wrong LLDP neighbor: ['Ethernet2']"]},
+        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'wrong_lldp_neighbor': ['Ethernet2']}"]},
     },
     {
-        "name": "failure-wrong-and-no-neighbor",
+        "name": "failure-multiple",
         "test": VerifyLLDPNeighbors,
         "inputs": {
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
+                {"port": "Ethernet3", "neighbor_device": "DC1-SPINE3", "neighbor_port": "Ethernet1"},
             ]
         },
         "eos_data": [
@@ -329,8 +362,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "The following port(s) have no LLDP neighbor: ['Ethernet2']",
-                "The following port(s) have the wrong LLDP neighbor: ['Ethernet1']",
+                "The following port(s) have issues: {'wrong_lldp_neighbor': ['Ethernet1'], 'no_lldp_neighbor': ['Ethernet2'], 'port_not_configured': ['Ethernet3']}"
             ],
         },
     },


### PR DESCRIPTION
# Description

Added a check in `VerifyLLDPNeighbors` when the interface is not configured on the device. The test will now fail and give a proper message instead of generating a `KeyError`.

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
