### PR TITLE
bump: Version 0.10.0 -> 0.11.0

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -26,7 +26,7 @@ $ pip install -e .[dev]
 $ pip list -e
 Package Version Editable project location
 ------- ------- -------------------------
-anta    0.10.0   /mnt/lab/projects/anta
+anta    0.11.0   /mnt/lab/projects/anta
 ```
 
 Then, [`tox`](https://tox.wiki/) is configued with few environments to run CI locally:

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -61,7 +61,7 @@ which anta
 ```bash
 # Check ANTA version
 anta --version
-anta, version v0.10.0
+anta, version v0.11.0
 ```
 
 ## EOS Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anta"
-version = "v0.10.0"
+version = "v0.11.0"
 readme = "docs/README.md"
 authors = [{ name = "Khelil Sator", email = "ksator@arista.com" }]
 maintainers = [
@@ -110,7 +110,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "0.10.0"
+current_version = "0.11.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New features and enhancements
* feat(anta.tests): New VXLAN tests by @carl-baillargeon in https://github.com/arista-netdevops-community/anta/pull/431
* feat(anta): Add tag mapping between devices and tests by @titom73 in https://github.com/arista-netdevops-community/anta/pull/377
* feat(anta.cli): Check catalog functionality by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/414
### Fixed issues
* fix(anta.tests): Fix VerifyLLDPNeighbors by @carl-baillargeon in https://github.com/arista-netdevops-community/anta/pull/430
* fix(anta.tests): Fix VerifyVxlanVtep result failure messages by @carl-baillargeon in https://github.com/arista-netdevops-community/anta/pull/433
* fix: improve error handling and ansible group parsing of anta get from-ansible by @mtache in https://github.com/arista-netdevops-community/anta/pull/449
### Other Changes
* chore: bump bumpver from 2023.1127 to 2023.1129 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/432
* chore: bump black from 23.9.1 to 23.10.1 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/435
* refactor(anta): Clean reporter typing by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/438
* chore: bump mike from 1.1.2 to 2.0.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/441
* chore: Reduce size of docker image by @titom73 in https://github.com/arista-netdevops-community/anta/pull/444
* chore: bump black from 23.10.1 to 23.11.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/446
* chore: Exclude direnv file by @titom73 in https://github.com/arista-netdevops-community/anta/pull/451


**Full Changelog**: https://github.com/arista-netdevops-community/anta/compare/v0.10.0...v0.11.0
