### PR TITLE
fix(anta.cli): Use configured anta inventory as output by default in get from-ansible

### DIFF
--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -86,8 +86,8 @@ def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_passw
 @click.option(
     "--output",
     "-o",
-    default="inventory-ansible.yml",
-    help="Path to save inventory file",
+    required=False,
+    help="Path to save inventory file. If not configured, use anta inventory file",
     type=click.Path(file_okay=True, dir_okay=False, exists=False, writable=True, path_type=Path),
 )
 def from_ansible(ctx: click.Context, output: Path, ansible_inventory: Path, ansible_group: str) -> None:
@@ -95,7 +95,9 @@ def from_ansible(ctx: click.Context, output: Path, ansible_inventory: Path, ansi
     logger.info(f"Building inventory from ansible file {ansible_inventory}")
 
     # Create output directory
+    output = output if output is not None else ctx.obj["inventory_path"]
     output.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(f"output anta inventory is: {output}")
     try:
         create_inventory_from_ansible(
             inventory=ansible_inventory,

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -78,7 +78,7 @@ def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_passw
 @click.option("--ansible-group", "-g", help="Ansible group to filter", type=str, required=False, default="all")
 @click.option(
     "--ansible-inventory",
-    "-i",
+    "-ai",
     default=None,
     help="Path to your ansible inventory file to read",
     type=click.Path(file_okay=True, dir_okay=False, exists=True, path_type=Path),

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -17,15 +17,14 @@ Usage: anta get from-ansible [OPTIONS]
   Build ANTA inventory from an ansible inventory YAML file
 
 Options:
-  -g, --ansible-group TEXT        Ansible group to filter
-  -i, --ansible-inventory FILENAME
-                                  Path to your ansible inventory file to read
-  -o, --output FILENAME           Path to save inventory file
-  -d, --inventory-directory PATH  Directory to save inventory file
-  --help                          Show this message and exit.
+  -g, --ansible-group TEXT       Ansible group to filter
+  -ai, --ansible-inventory FILE  Path to your ansible inventory file to read
+  -o, --output FILE              Path to save inventory file. If not
+                                 configured, use anta inventory file
+  --help                         Show this message and exit.
 ```
 
-The output is an inventory where the name of the container is added as a tag for each host:
+The output is an inventory where the name of the container is added as a tag for each host. By default, anta cli saves output in anta inventory configured under `anta --inventory` and can be overwritten with `--output` option:
 
 ```yaml
 anta_inventory:

--- a/tests/data/test_inventory.yml
+++ b/tests/data/test_inventory.yml
@@ -1,12 +1,10 @@
----
 anta_inventory:
   hosts:
-    - name: dummy
-      host: dummy.anta.ninja
-      tags: ["leaf"]
-    - name: dummy2
-      host: dummy2.anta.ninja
-      tags: ["leaf"]
-    - name: dummy3
-      host: dummy3.anta.ninja
-      tags: ["spine"]
+  - host: 192.168.0.12
+    name: leaf1
+  - host: 192.168.0.13
+    name: leaf2
+  - host: 192.168.0.14
+    name: leaf3
+  - host: 192.168.0.15
+    name: leaf4

--- a/tests/units/cli/get/test_commands.py
+++ b/tests/units/cli/get/test_commands.py
@@ -103,12 +103,13 @@ def test_from_cvp(
     "ansible_inventory, ansible_group, output, expected_exit",
     [
         pytest.param("ansible_inventory.yml", None, None, 0, id="no group"),
+        pytest.param("ansible_inventory.yml", None, "inventory.yml", 0, id="output defined"),
         pytest.param("ansible_inventory.yml", "ATD_LEAFS", None, 0, id="group found"),
         pytest.param("ansible_inventory.yml", "DUMMY", None, 4, id="group not found"),
         pytest.param("empty_ansible_inventory.yml", None, None, 4, id="empty inventory"),
     ],
 )
-# pylint: disable-next=too-many-arguments
+# pylint: disable=too-many-arguments
 def test_from_ansible(
     tmp_path: Path,
     caplog: LogCaptureFixture,
@@ -132,7 +133,7 @@ def test_from_ansible(
     else:
         # Get inventory-directory default
         default_dir: Path = cast(Path, from_ansible.params[2].default)
-        out_dir = Path() / default_dir
+        out_dir = Path() / default_dir if default_dir is not None else Path()
 
     if ansible_inventory is not None:
         ansible_inventory_path = DATA_DIR / ansible_inventory
@@ -150,6 +151,6 @@ def test_from_ansible(
     assert result.exit_code == expected_exit
     print(caplog.records)
     if expected_exit != 0:
-        assert len(caplog.records) == 2
+        assert len(caplog.records) in {2, 3}
     else:
         assert out_dir.exists()


### PR DESCRIPTION
# Description

<!-- PR description !-->

Use configured anta inventory by default in anta get from-ansible command. Also the knob `-i` for ansible-inventory has been renamed `-ai` to avoid confusion with anta inventory.

```bash
❯ anta get from-ansible --ansible-inventory .personal/ansible.yml -g ATD_LEAFS
[14:22:50] INFO     Building inventory from ansible file .personal/ansible.yml              
           INFO     output anta inventory is: .personal/inventory.yml                       
           INFO        * adding entry for s1-leaf1                                          
           INFO        * adding entry for s1-leaf2                                          
           INFO        * adding entry for s1-leaf3                                          
           INFO        * adding entry for s1-leaf4                                          
           INFO     ANTA device inventory file has been created in .personal/inventory.yml  
```

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
