### PR TITLE
fix(anta.cli)!: Remove confusing -i option in anta get from-ansible

### DIFF
--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -78,7 +78,6 @@ def from_cvp(inventory_directory: str, cvp_ip: str, cvp_username: str, cvp_passw
 @click.option("--ansible-group", "-g", help="Ansible group to filter", type=str, required=False, default="all")
 @click.option(
     "--ansible-inventory",
-    "-i",
     default=None,
     help="Path to your ansible inventory file to read",
     type=click.Path(file_okay=True, dir_okay=False, exists=True, path_type=Path),

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -18,7 +18,7 @@ Usage: anta get from-ansible [OPTIONS]
 
 Options:
   -g, --ansible-group TEXT        Ansible group to filter
-  -i, --ansible-inventory FILENAME
+  --ansible-inventory FILENAME
                                   Path to your ansible inventory file to read
   -o, --output FILENAME           Path to save inventory file
   -d, --inventory-directory PATH  Directory to save inventory file


### PR DESCRIPTION
# Description

<!-- PR description !-->

Remove a confusing option (`-i`) from the cli under `anta get from-ansible`

```
anta get from-ansible --help
Usage: anta get from-ansible [OPTIONS]

  Build ANTA inventory from an ansible inventory YAML file

Options:
  -g, --ansible-group TEXT        Ansible group to filter
  --ansible-inventory FILENAME
                                  Path to your ansible inventory file to read
  -o, --output FILENAME           Path to save inventory file
  -d, --inventory-directory PATH  Directory to save inventory file
  --help                          Show this message and exit.
```

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
