### PR TITLE
feat(anta.tests)!: Adding the test case to verify BGP neighbor routes

### DIFF
--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -9,7 +9,7 @@ BGP test functions
 from __future__ import annotations
 
 from ipaddress import IPv4Address, IPv6Address
-from typing import Any, List, Optional, Union, cast
+from typing import Any, Iterable, List, Optional, Union, cast
 
 from pydantic import BaseModel, PositiveInt, model_validator, utils
 
@@ -498,6 +498,9 @@ class VerifyBGPExchangedRoutes(AntaTest):
             vrf = command.params.get("vrf")
             advertised_routes = command.params.get("advertised_routes")
             received_routes = command.params.get("received_routes")
+            if not isinstance(advertised_routes, Iterable) or not isinstance(received_routes, Iterable):
+                self.result.is_failure("BGP advertised or received routes are not iterable from the test catalog.")
+                return
 
             # Verify if BGP neighbor is configured with provided vrf
             if (bgp_routes := get_value(command.json_output, f"vrfs..{vrf}", separator="..")) is None:

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -8,7 +8,7 @@ BGP test functions
 # mypy: disable-error-code=attr-defined
 from __future__ import annotations
 
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv4Network, IPv6Address
 from typing import Any, List, Optional, Union, cast
 
 from pydantic import BaseModel, PositiveInt, model_validator, utils
@@ -157,6 +157,7 @@ def _add_bgp_routes_failure(
 
     # Iterate over the expected bgp routes
     for route in bgp_routes:
+        route = str(route)
         # Check if the route is missing in the BGP output
         if route not in bgp_output:
             # If missing, add it to the failure routes dictionary
@@ -529,9 +530,9 @@ class VerifyBGPExchangedRoutes(AntaTest):
             """IPv4 address of a BGP peer"""
             vrf: str = "default"
             """Optional VRF for BGP peer. If not provided, it defaults to `default`."""
-            advertised_routes: List[str]
+            advertised_routes: List[IPv4Network]
             """List of advertised routes of a BGP peer."""
-            received_routes: List[str]
+            received_routes: List[IPv4Network]
             """List of received routes of a BGP peer."""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -132,44 +132,46 @@ def _check_peer_issues(peer_data: Optional[dict[str, Any]]) -> dict[str, Any]:
     return {}
 
 
-def _add_bgp_routes_failure(bgp_routes: List[str], bgp_output: dict[str, Any], neighbor: str, vrf: str, route_type: str = "advertised_routes") -> dict[str, Any]:
+def _add_bgp_routes_failure(
+    bgp_routes: List[str], bgp_output: dict[str, Any], neighbor: str, vrf: str, route_type: str = "advertised_routes"
+) -> dict[str, dict[str, dict[str, dict[str, list[str]]]]]:
     """
-        Add the missing BGP advertised/received routes and invalid or inactive route entries to the given `failures` dictionary.
+    Add the missing BGP advertised/received routes and invalid or inactive route entries to the given `failures` dictionary.
 
-        Parameters:
-            bgp_routes (list): The list of routes that need to be checked.
-            bgp_output (dict): BGP output from the device.
-            neighbor (str): BGP neighbor IP address.
-            vrf (str): VRF name for which need to verify the routes.
-            route_type (str): Type of BGP routes, default as advertised routes.
+    Parameters:
+        bgp_routes (list): The list of routes that need to be checked.
+        bgp_output (dict): BGP output from the device.
+        neighbor (str): BGP neighbor IP address.
+        vrf (str): VRF name for which need to verify the routes.
+        route_type (str): Type of BGP routes, default as advertised routes.
 
-        The `failures` dictionnary will have the following structure:
-           {
-       "advertised_routes":{
-          "default":{
-             "172.30.11.1":{
-                "missing_routes":[
-                   "192.0.254.31/32"
-                ],
-                "invalid_or_inactive_routes":[
-                   "192.0.255.4/32"
-                ]
-             }
-          }
-       },
-       "revevied_routes":{
-          "default":{
-             "172.30.11.1":{
-                "missing_routes":[
-                   "192.0.254.31/32"
-                ],
-                "invalid_or_inactive_routes":[
-                   "192.0.255.4/32"
-                ]
-             }
-          }
-       }
-    }
+    The `failures` dictionary will have the following structure:
+       {
+            "advertised_routes":{
+                <vrf>:{
+                    <neighbor>:{
+                        "missing_routes":[
+                        <route>
+                        ],
+                        "invalid_or_inactive_routes":[
+                        <route>
+                        ]
+                    }
+                }
+            },
+            "revevied_routes":{
+                <vrf>:{
+                    <neighbor>:{
+                        "missing_routes":[
+                        <route>"
+                        ],
+                        "invalid_or_inactive_routes":[
+                        <route>
+                        ]
+                    }
+                }
+            }
+        }
     """
     failure_routes = {}
     missing_routes = [route for route in bgp_routes if route not in bgp_output]

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, List, Optional, Union, cast
 
-from pydantic import BaseModel, PositiveInt, model_validator
+from pydantic import BaseModel, PositiveInt, model_valid
 
 from anta.custom_types import Afi, Safi
 from anta.models import AntaCommand, AntaTemplate, AntaTest
@@ -505,22 +505,21 @@ class VerifyBGPExchangedRoutes(AntaTest):
                 self.result.is_failure(f"BGP routes are not found for `{neighbor}` neighbor.")
                 return
 
+            routes = []
             if "advertised-routes" in command.command:
-                routes = []
                 for route in advertised_routes:
                     if route not in bgp_routes:
                         routes.append(route)
                 if routes:
                     failures["advertised_routes"].update({str(neighbor): routes})
             else:
-                routes = []
                 for route in received_routes:
                     if route not in bgp_routes:
                         routes.append(route)
                 if routes:
                     failures["received_routes"].update({str(neighbor): routes})
 
-        if not failures.get("advertised_routes") or failures.get("received_routes"):
+        if not failures.get("advertised_routes") and failures.get("received_routes"):
             self.result.is_success()
         else:
             self.result.is_failure(f"Following BGP routes are not redistributed: {failures}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -320,6 +320,21 @@ anta.tests.routing:
               - 10.1.255.0
               - 10.1.255.2
               - 10.1.255.4
+    - VerifyBGPExchangedRoutes:
+        bgp_neighbors:
+          - neighbor: 172.30.255.5
+            vrf: default
+            advertised_routes:
+              - 192.0.254.5/32
+            received_routes:
+              - 192.0.255.4/32
+          - neighbor: 172.30.255.1
+            vrf: default
+            advertised_routes:
+              - 192.0.255.1/32
+              - 192.0.254.5/32
+            received_routes:
+              - 192.0.254.3/32
   ospf:
     - VerifyOSPFNeighborState:
     - VerifyOSPFNeighborCount:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -322,13 +322,13 @@ anta.tests.routing:
               - 10.1.255.4
     - VerifyBGPExchangedRoutes:
         bgp_peers:
-          - peer: 172.30.255.5
+          - peer_address: 172.30.255.5
             vrf: default
             advertised_routes:
               - 192.0.254.5/32
             received_routes:
               - 192.0.255.4/32
-          - peer: 172.30.255.1
+          - peer_address: 172.30.255.1
             vrf: default
             advertised_routes:
               - 192.0.255.1/32

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -321,14 +321,14 @@ anta.tests.routing:
               - 10.1.255.2
               - 10.1.255.4
     - VerifyBGPExchangedRoutes:
-        bgp_neighbors:
-          - neighbor: 172.30.255.5
+        bgp_peers:
+          - peer: 172.30.255.5
             vrf: default
             advertised_routes:
               - 192.0.254.5/32
             received_routes:
               - 192.0.255.4/32
-          - neighbor: 172.30.255.1
+          - peer: 172.30.255.1
             vrf: default
             advertised_routes:
               - 192.0.255.1/32

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1246,189 +1246,16 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
                                         "routeType": {
-                                            "stale": False,
                                             "valid": True,
-                                            "suppressed": False,
                                             "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
                                     }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
+                                ]
                             },
                         },
                     }
@@ -1437,380 +1264,17 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
                                         "routeType": {
-                                            "stale": False,
                                             "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
                                             "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
                                     }
                                 ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
+                            }
                         },
                     }
                 }
@@ -1819,15 +1283,9 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.255.5",
+                    "neighbor": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.5/32"],
-                    "received_routes": ["92.0.255.4/32"],
-                },
-                {
-                    "neighbor": "172.30.255.1",
-                    "vrf": "default",
-                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
+                    "advertised_routes": ["192.0.254.3/32"],
                     "received_routes": ["192.0.254.3/32"],
                 },
             ]
@@ -1840,53 +1298,39 @@ DATA: list[dict[str, Any]] = [
         "eos_data": [
             {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
             {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
-            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
-            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
         ],
         "inputs": {
             "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.255.51",
+                    "neighbor": "172.30.11.11",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.5/32"],
-                    "received_routes": ["92.0.255.4/32"],
-                },
-                {
-                    "neighbor": "172.30.255.11",
-                    "vrf": "default",
-                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
-                    "received_routes": ["192.0.254.3/32"],
+                    "advertised_routes": ["192.0.254.3/32"],
+                    "received_routes": ["192.0.255.3/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": "BGP routes are not found for neighbor `172.30.255.51`.",
+            "messages": ["BGP routes are not found for neighbor `172.30.11.11`."],
         },
     },
     {
         "name": "failure-no-neighbor",
         "test": VerifyBGPExchangedRoutes,
-        "eos_data": [{"vrfs": {}}, {"vrfs": {}}, {"vrfs": {}}, {"vrfs": {}}],
+        "eos_data": [{"vrfs": {}}, {"vrfs": {}}],
         "inputs": {
             "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.255.5",
+                    "neighbor": "172.30.11.11",
                     "vrf": "MGMT",
-                    "advertised_routes": ["192.0.254.5/32"],
-                    "received_routes": ["92.0.255.4/32"],
-                },
-                {
-                    "neighbor": "172.30.255.1",
-                    "vrf": "MGMT",
-                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
-                    "received_routes": ["192.0.254.3/32"],
+                    "advertised_routes": ["192.0.254.3/32"],
+                    "received_routes": ["192.0.255.3/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": "BGP neighbor 172.30.255.5 is not configured for `MGMT` VRF.",
+            "messages": ["BGP neighbor 172.30.11.11 is not configured for `MGMT` VRF."],
         },
     },
     {
@@ -1896,189 +1340,16 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
                                         "routeType": {
-                                            "stale": False,
                                             "valid": True,
-                                            "suppressed": False,
                                             "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
                                     }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
+                                ]
                             },
                         },
                     }
@@ -2087,380 +1358,17 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
                                         "routeType": {
-                                            "stale": False,
                                             "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
                                             "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
                                     }
                                 ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
+                            }
                         },
                     }
                 }
@@ -2469,27 +1377,19 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.255.5",
+                    "neighbor": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.51/32"],
-                    "received_routes": ["92.0.255.41/32"],
-                },
-                {
-                    "neighbor": "172.30.255.1",
-                    "vrf": "default",
-                    "advertised_routes": ["192.0.255.11/32", "192.0.254.5/32"],
-                    "received_routes": ["192.0.254.31/32"],
+                    "advertised_routes": ["192.0.254.31/32"],
+                    "received_routes": ["192.0.255.31/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": "Following BGP neighbors are not ok: {'advertised_routes':"
-            "{'default': {'172.30.255.5': {'missing_routes':"
-            "['192.0.254.51/32']}, '172.30.255.1': {'missing_routes':"
-            "['192.0.255.11/32']}}}, 'received_routes': {'default':"
-            "{'172.30.255.5': {'missing_routes': ['192.0.255.41/32']},"
-            "'172.30.255.1': {'missing_routes': ['192.0.254.31/32']}}}}",
+            "messages": [
+                "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.254.31/32']}}}, "
+                "'revevied_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.31/32']}}}}"
+            ],
         },
     },
     {
@@ -2499,189 +1399,16 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
                                         "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
+                                            "valid": False,
+                                            "active": False,
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
                                     }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.4",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
+                                ]
                             },
                         },
                     }
@@ -2690,380 +1417,17 @@ DATA: list[dict[str, Any]] = [
             {
                 "vrfs": {
                     "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.5/32": {
-                                "address": "192.0.254.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.1/32": {
-                                "address": "192.0.255.1",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
-                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.5/32": {
-                                "address": "192.0.255.5",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.6/32": {
-                                "address": "192.0.255.6",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.0",
-                                        "reasonNotBestpath": "noReason",
-                                        "tag": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
                         "bgpRouteEntries": {
                             "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
                                 "bgpRoutePaths": [
                                     {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
                                         "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
+                                            "valid": False,
                                             "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
                                         },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
                                     }
                                 ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.5",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                        },
-                    }
-                }
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "vrf": "default",
-                        "routerId": "192.0.255.1",
-                        "asn": "65001",
-                        "bgpRouteEntries": {
-                            "192.0.254.3/32": {
-                                "address": "192.0.254.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": True,
-                                            "ecmp": True,
-                                            "ecmpContributor": True,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.3/32": {
-                                "address": "192.0.255.3",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": True,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Igp",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
-                            "192.0.255.4/32": {
-                                "address": "192.0.255.4",
-                                "maskLength": 32,
-                                "bgpRoutePaths": [
-                                    {
-                                        "nextHop": "172.30.255.1",
-                                        "reasonNotBestpath": "noReason",
-                                        "localPreference": 100,
-                                        "weight": 0,
-                                        "tag": 0,
-                                        "med": 0,
-                                        "routeType": {
-                                            "stale": False,
-                                            "valid": True,
-                                            "suppressed": False,
-                                            "active": False,
-                                            "backup": False,
-                                            "ecmpHead": False,
-                                            "ecmp": False,
-                                            "ecmpContributor": False,
-                                            "atomicAggregator": False,
-                                            "queued": False,
-                                            "luRoute": False,
-                                            "sixPeRoute": False,
-                                            "ucmp": False,
-                                            "origin": "Incomplete",
-                                        },
-                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
-                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
-                                    }
-                                ],
-                                "totalPaths": 1,
-                            },
+                            }
                         },
                     }
                 }
@@ -3072,25 +1436,19 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.255.5",
+                    "neighbor": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.5/32"],
-                    "received_routes": ["192.0.255.4/32", "192.0.255.3/32"],
-                },
-                {
-                    "neighbor": "172.30.255.1",
-                    "vrf": "default",
-                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
-                    "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
+                    "advertised_routes": ["192.0.254.3/32"],
+                    "received_routes": ["192.0.255.3/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": "Following BGP neighbors are not ok: {'received_routes': {'default':"
-            "{'172.30.255.5': {'invalid_or_inactive_routes': ['192.0.255.3/32']},"
-            "'172.30.255.1': {'invalid_or_inactive_routes': ['192.0.254.3/32',"
-            "'192.0.255.4/32']}}}}",
+            "messages": [
+                "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'invalid_or_inactive_routes': ['192.0.254.3/32']}}}, "
+                "'revevied_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.3/32']}}}}"
+            ],
         },
     },
 ]

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -11,7 +11,7 @@ from typing import Any
 
 # pylint: disable=C0413
 # because of the patch above
-from anta.tests.routing.bgp import VerifyBGPPeerCount, VerifyBGPPeersHealth, VerifyBGPSpecificPeers  # noqa: E402
+from anta.tests.routing.bgp import VerifyBGPExchangedRoutes, VerifyBGPPeerCount, VerifyBGPPeersHealth, VerifyBGPSpecificPeers  # noqa: E402
 from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
 
 DATA: list[dict[str, Any]] = [
@@ -1237,6 +1237,1860 @@ DATA: list[dict[str, Any]] = [
                 "{'afi': 'ipv6', 'safi': 'unicast', 'vrfs': {'default': 'Not Configured'}}, "
                 "{'afi': 'evpn', 'vrfs': {'default': {'10.1.0.2': {'peerState': 'Idle', 'inMsgQueue': 0, 'outMsgQueue': 0}}}"
             ],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "bgp_neighbors": [
+                {
+                    "neighbor": "172.30.255.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.5/32"],
+                    "received_routes": ["92.0.255.4/32"],
+                },
+                {
+                    "neighbor": "172.30.255.1",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32"],
+                },
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-no-routes",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+        ],
+        "inputs": {
+            "bgp_neighbors": [
+                {
+                    "neighbor": "172.30.255.51",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.5/32"],
+                    "received_routes": ["92.0.255.4/32"],
+                },
+                {
+                    "neighbor": "172.30.255.11",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32"],
+                },
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": "BGP routes are not found for neighbor `172.30.255.51`.",
+        },
+    },
+    {
+        "name": "failure-no-neighbor",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [{"vrfs": {}}, {"vrfs": {}}, {"vrfs": {}}, {"vrfs": {}}],
+        "inputs": {
+            "bgp_neighbors": [
+                {
+                    "neighbor": "172.30.255.5",
+                    "vrf": "MGMT",
+                    "advertised_routes": ["192.0.254.5/32"],
+                    "received_routes": ["92.0.255.4/32"],
+                },
+                {
+                    "neighbor": "172.30.255.1",
+                    "vrf": "MGMT",
+                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32"],
+                },
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": "BGP neighbor 172.30.255.5 is not configured for `MGMT` VRF.",
+        },
+    },
+    {
+        "name": "failure-missing-routes",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "bgp_neighbors": [
+                {
+                    "neighbor": "172.30.255.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.51/32"],
+                    "received_routes": ["92.0.255.41/32"],
+                },
+                {
+                    "neighbor": "172.30.255.1",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.255.11/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.31/32"],
+                },
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": "Following BGP neighbors are not ok: {'advertised_routes':"
+            "{'default': {'172.30.255.5': {'missing_routes':"
+            "['192.0.254.51/32']}, '172.30.255.1': {'missing_routes':"
+            "['192.0.255.11/32']}}}, 'received_routes': {'default':"
+            "{'172.30.255.5': {'missing_routes': ['192.0.255.41/32']},"
+            "'172.30.255.1': {'missing_routes': ['192.0.254.31/32']}}}}",
+        },
+    },
+    {
+        "name": "failure-invalid-or-inactive-routes",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.4",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.5/32": {
+                                "address": "192.0.254.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.1/32": {
+                                "address": "192.0.255.1",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "", "peerRouterId": "0.0.0.0"},
+                                        "asPathEntry": {"asPathType": "Local", "asPath": "65001 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.5/32": {
+                                "address": "192.0.255.5",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.9", "peerRouterId": "192.0.255.5"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.6/32": {
+                                "address": "192.0.255.6",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.0",
+                                        "reasonNotBestpath": "noReason",
+                                        "tag": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.13", "peerRouterId": "192.0.255.6"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65001 65102 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.5",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.5", "peerRouterId": "192.0.255.4"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "vrf": "default",
+                        "routerId": "192.0.255.1",
+                        "asn": "65001",
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "address": "192.0.254.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": True,
+                                            "ecmp": True,
+                                            "ecmpContributor": True,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.3/32": {
+                                "address": "192.0.255.3",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": True,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Igp",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 i"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                            "192.0.255.4/32": {
+                                "address": "192.0.255.4",
+                                "maskLength": 32,
+                                "bgpRoutePaths": [
+                                    {
+                                        "nextHop": "172.30.255.1",
+                                        "reasonNotBestpath": "noReason",
+                                        "localPreference": 100,
+                                        "weight": 0,
+                                        "tag": 0,
+                                        "med": 0,
+                                        "routeType": {
+                                            "stale": False,
+                                            "valid": True,
+                                            "suppressed": False,
+                                            "active": False,
+                                            "backup": False,
+                                            "ecmpHead": False,
+                                            "ecmp": False,
+                                            "ecmpContributor": False,
+                                            "atomicAggregator": False,
+                                            "queued": False,
+                                            "luRoute": False,
+                                            "sixPeRoute": False,
+                                            "ucmp": False,
+                                            "origin": "Incomplete",
+                                        },
+                                        "peerEntry": {"peerAddr": "172.30.255.1", "peerRouterId": "192.0.255.3"},
+                                        "asPathEntry": {"asPathType": "External", "asPath": "65101 ?"},
+                                    }
+                                ],
+                                "totalPaths": 1,
+                            },
+                        },
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "bgp_neighbors": [
+                {
+                    "neighbor": "172.30.255.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.5/32"],
+                    "received_routes": ["192.0.255.4/32", "192.0.255.3/32"],
+                },
+                {
+                    "neighbor": "172.30.255.1",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.255.1/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
+                },
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": "Following BGP neighbors are not ok: {'received_routes': {'default':"
+            "{'172.30.255.5': {'invalid_or_inactive_routes': ['192.0.255.3/32']},"
+            "'172.30.255.1': {'invalid_or_inactive_routes': ['192.0.254.3/32',"
+            "'192.0.255.4/32']}}}}",
         },
     },
 ]

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1359,13 +1359,13 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_peers": [
                 {
-                    "peer": "172.30.11.1",
+                    "peer_address": "172.30.11.1",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.5/32", "192.0.254.3/32"],
                     "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
                 },
                 {
-                    "peer": "172.30.11.5",
+                    "peer_address": "172.30.11.5",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32", "192.0.254.5/32"],
                     "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
@@ -1386,13 +1386,13 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_peers": [
                 {
-                    "peer": "172.30.11.11",
+                    "peer_address": "172.30.11.11",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32"],
                     "received_routes": ["192.0.255.3/32"],
                 },
                 {
-                    "peer": "172.30.11.12",
+                    "peer_address": "172.30.11.12",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.31/32"],
                     "received_routes": ["192.0.255.31/32"],
@@ -1474,13 +1474,13 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_peers": [
                 {
-                    "peer": "172.30.11.11",
+                    "peer_address": "172.30.11.11",
                     "vrf": "MGMT",
                     "advertised_routes": ["192.0.254.3/32"],
                     "received_routes": ["192.0.255.3/32"],
                 },
                 {
-                    "peer": "172.30.11.5",
+                    "peer_address": "172.30.11.5",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32", "192.0.254.5/32"],
                     "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
@@ -1612,13 +1612,13 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_peers": [
                 {
-                    "peer": "172.30.11.1",
+                    "peer_address": "172.30.11.1",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32", "192.0.254.51/32"],
                     "received_routes": ["192.0.254.31/32", "192.0.255.4/32"],
                 },
                 {
-                    "peer": "172.30.11.5",
+                    "peer_address": "172.30.11.5",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.31/32", "192.0.254.5/32"],
                     "received_routes": ["192.0.254.3/32", "192.0.255.41/32"],
@@ -1754,13 +1754,13 @@ DATA: list[dict[str, Any]] = [
         "inputs": {
             "bgp_peers": [
                 {
-                    "peer": "172.30.11.1",
+                    "peer_address": "172.30.11.1",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32", "192.0.254.51/32"],
                     "received_routes": ["192.0.254.31/32", "192.0.255.4/32"],
                 },
                 {
-                    "peer": "172.30.11.5",
+                    "peer_address": "172.30.11.5",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.31/32", "192.0.254.5/32"],
                     "received_routes": ["192.0.254.3/32", "192.0.255.41/32"],

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1402,9 +1402,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BGP peers are not found or routes are not exchanged properly:\n{'bgp_peers': "
-                "{'172.30.11.11': {'default': {'advertised_routes': {'192.0.254.3/32': 'Not found'}, 'received_routes': {'192.0.255.3/32': 'Not found'}}}, "
-                "'172.30.11.12': {'default': {'advertised_routes': {'192.0.254.31/32': 'Not found'}, 'received_routes': {'192.0.255.31/32': 'Not found'}}}}}"
+                "Following BGP peers are not found or routes are not exchanged properly:\n"
+                "{'bgp_peers': {'172.30.11.11': {'default': 'Not configured'}, '172.30.11.12': {'default': 'Not configured'}}}"
             ],
         },
     },

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1388,7 +1388,7 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": [
                 "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.254.31/32']}}}, "
-                "'revevied_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.31/32']}}}}"
+                "'received_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.31/32']}}}}"
             ],
         },
     },
@@ -1447,7 +1447,7 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": [
                 "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'invalid_or_inactive_routes': ['192.0.254.3/32']}}}, "
-                "'revevied_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.3/32']}}}}"
+                "'received_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.3/32']}}}}"
             ],
         },
     },

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1257,6 +1257,44 @@ DATA: list[dict[str, Any]] = [
                                     }
                                 ]
                             },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
                         },
                     }
                 }
@@ -1274,19 +1312,63 @@ DATA: list[dict[str, Any]] = [
                                         },
                                     }
                                 ],
-                            }
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
                         },
                     }
                 }
             },
         ],
         "inputs": {
-            "bgp_neighbors": [
+            "bgp_peers": [
                 {
-                    "neighbor": "172.30.11.1",
+                    "peer": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.3/32"],
-                    "received_routes": ["192.0.254.3/32"],
+                    "advertised_routes": ["192.0.254.5/32", "192.0.254.3/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
+                },
+                {
+                    "peer": "172.30.11.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.3/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
                 },
             ]
         },
@@ -1298,39 +1380,116 @@ DATA: list[dict[str, Any]] = [
         "eos_data": [
             {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
             {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
+            {"vrfs": {"default": {"vrf": "default", "routerId": "192.0.255.1", "asn": "65001", "bgpRouteEntries": {}}}},
         ],
         "inputs": {
-            "bgp_neighbors": [
+            "bgp_peers": [
                 {
-                    "neighbor": "172.30.11.11",
+                    "peer": "172.30.11.11",
                     "vrf": "default",
                     "advertised_routes": ["192.0.254.3/32"],
                     "received_routes": ["192.0.255.3/32"],
                 },
-            ]
-        },
-        "expected": {
-            "result": "failure",
-            "messages": ["BGP routes are not found for neighbor `172.30.11.11`."],
-        },
-    },
-    {
-        "name": "failure-no-neighbor",
-        "test": VerifyBGPExchangedRoutes,
-        "eos_data": [{"vrfs": {}}, {"vrfs": {}}],
-        "inputs": {
-            "bgp_neighbors": [
                 {
-                    "neighbor": "172.30.11.11",
-                    "vrf": "MGMT",
-                    "advertised_routes": ["192.0.254.3/32"],
-                    "received_routes": ["192.0.255.3/32"],
+                    "peer": "172.30.11.12",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.31/32"],
+                    "received_routes": ["192.0.255.31/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": ["BGP neighbor 172.30.11.11 is not configured for `MGMT` VRF."],
+            "messages": [
+                "Following BGP peers are not found or routes are not exchanged properly:\n{'bgp_peers': "
+                "{'172.30.11.11': {'default': {'advertised_routes': {'192.0.254.3/32': 'Not found'}, 'received_routes': {'192.0.255.3/32': 'Not found'}}}, "
+                "'172.30.11.12': {'default': {'advertised_routes': {'192.0.254.31/32': 'Not found'}, 'received_routes': {'192.0.255.31/32': 'Not found'}}}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-no-peer",
+        "test": VerifyBGPExchangedRoutes,
+        "eos_data": [
+            {"vrfs": {}},
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                }
+            },
+            {"vrfs": {}},
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {
+                    "peer": "172.30.11.11",
+                    "vrf": "MGMT",
+                    "advertised_routes": ["192.0.254.3/32"],
+                    "received_routes": ["192.0.255.3/32"],
+                },
+                {
+                    "peer": "172.30.11.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.3/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.4/32"],
+                },
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": ["Following BGP peers are not found or routes are not exchanged properly:\n{'bgp_peers': {'172.30.11.11': {'MGMT': 'Not configured'}}}"],
         },
     },
     {
@@ -1351,6 +1510,44 @@ DATA: list[dict[str, Any]] = [
                                     }
                                 ]
                             },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
                         },
                     }
                 }
@@ -1368,27 +1565,72 @@ DATA: list[dict[str, Any]] = [
                                         },
                                     }
                                 ],
-                            }
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": True,
+                                        },
+                                    }
+                                ],
+                            },
                         },
                     }
                 }
             },
         ],
         "inputs": {
-            "bgp_neighbors": [
+            "bgp_peers": [
                 {
-                    "neighbor": "172.30.11.1",
+                    "peer": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.31/32"],
-                    "received_routes": ["192.0.255.31/32"],
+                    "advertised_routes": ["192.0.254.3/32", "192.0.254.51/32"],
+                    "received_routes": ["192.0.254.31/32", "192.0.255.4/32"],
+                },
+                {
+                    "peer": "172.30.11.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.31/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.41/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.254.31/32']}}}, "
-                "'received_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.31/32']}}}}"
+                "Following BGP peers are not found or routes are not exchanged properly:\n{'bgp_peers': "
+                "{'172.30.11.1': {'default': {'advertised_routes': {'192.0.254.51/32': 'Not found'}, 'received_routes': {'192.0.254.31/32': 'Not found'}}}, "
+                "'172.30.11.5': {'default': {'advertised_routes': {'192.0.254.31/32': 'Not found'}, 'received_routes': {'192.0.255.41/32': 'Not found'}}}}}"
             ],
         },
     },
@@ -1405,7 +1647,45 @@ DATA: list[dict[str, Any]] = [
                                     {
                                         "routeType": {
                                             "valid": False,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
                                             "active": False,
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": False,
+                                            "active": True,
+                                        },
+                                    }
+                                ]
+                            },
+                            "192.0.254.5/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": False,
+                                            "active": True,
                                         },
                                     }
                                 ]
@@ -1427,27 +1707,74 @@ DATA: list[dict[str, Any]] = [
                                         },
                                     }
                                 ],
-                            }
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": False,
+                                            "active": False,
+                                        },
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                }
+            },
+            {
+                "vrfs": {
+                    "default": {
+                        "bgpRouteEntries": {
+                            "192.0.254.3/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": False,
+                                        },
+                                    }
+                                ],
+                            },
+                            "192.0.255.4/32": {
+                                "bgpRoutePaths": [
+                                    {
+                                        "routeType": {
+                                            "valid": True,
+                                            "active": False,
+                                        },
+                                    }
+                                ],
+                            },
                         },
                     }
                 }
             },
         ],
         "inputs": {
-            "bgp_neighbors": [
+            "bgp_peers": [
                 {
-                    "neighbor": "172.30.11.1",
+                    "peer": "172.30.11.1",
                     "vrf": "default",
-                    "advertised_routes": ["192.0.254.3/32"],
-                    "received_routes": ["192.0.255.3/32"],
+                    "advertised_routes": ["192.0.254.3/32", "192.0.254.51/32"],
+                    "received_routes": ["192.0.254.31/32", "192.0.255.4/32"],
+                },
+                {
+                    "peer": "172.30.11.5",
+                    "vrf": "default",
+                    "advertised_routes": ["192.0.254.31/32", "192.0.254.5/32"],
+                    "received_routes": ["192.0.254.3/32", "192.0.255.41/32"],
                 },
             ]
         },
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BGP neighbors are not ok: {'advertised_routes': {'default': {'172.30.11.1': {'invalid_or_inactive_routes': ['192.0.254.3/32']}}}, "
-                "'received_routes': {'default': {'172.30.11.1': {'missing_routes': ['192.0.255.3/32']}}}}"
+                "Following BGP peers are not found or routes are not exchanged properly:\n{'bgp_peers': "
+                "{'172.30.11.1': {'default': {'advertised_routes': {'192.0.254.3/32': {'valid': True, 'active': False}, '192.0.254.51/32': 'Not found'}, "
+                "'received_routes': {'192.0.254.31/32': 'Not found', '192.0.255.4/32': {'valid': False, 'active': False}}}}, "
+                "'172.30.11.5': {'default': {'advertised_routes': {'192.0.254.31/32': 'Not found', '192.0.254.5/32': {'valid': True, 'active': False}}, "
+                "'received_routes': {'192.0.254.3/32': {'valid': False, 'active': True}, '192.0.255.41/32': 'Not found'}}}}}"
             ],
         },
     },


### PR DESCRIPTION
# Description

Add the test case to verify the BGP neighbor routes 

Run the testcase by adding catalog as below:
```
anta.tests.routing:
  bgp:
    - VerifyBGPExchangedRoutes:
        bgp_peers:
          - peer_address: 172.30.255.5
            vrf: default
            advertised_routes:
              - 192.0.254.5/32
            received_routes:
              - 192.0.255.4/32
          - peer_address: 172.30.255.1
            vrf: default
            advertised_routes:
              - 192.0.255.1/32
              - 192.0.254.5/32
            received_routes:
              - 192.0.254.3/32
```
1. Testcase pass when routes are correct:
```
                                                                                          All tests results                                                                                           
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Device    ┃ Test Name                ┃ Test Status ┃ Message(s) ┃ Test description                                                                                                 ┃ Test category ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ s1-spine1 │ VerifyBGPExchangedRoutes │ success     │            │ Verifies if BGP peers have correctly advertised/received routes with type as valid and active for a specified    │ routing, bgp  │
│           │                          │             │            │ VRF.                                                                                                             │               │
└───────────┴──────────────────────────┴─────────────┴────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────────┘
```
2. Testcase fail when routes are missing:
```
                                                                                          All tests results                                                                                           
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Device    ┃ Test Name                ┃ Test Status ┃ Message(s)                                                    ┃ Test description                                              ┃ Test category ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ s1-spine1 │ VerifyBGPExchangedRoutes │ failure     │ Following BGP peers are not found or routes are not exchanged │ Verifies if BGP peers have correctly advertised/received      │ routing, bgp  │
│           │                          │             │ properly:                                                     │ routes with type as valid and active for a specified VRF.     │               │
│           │                          │             │ {'bgp_peers': {'172.30.11.1': {'MGMT': 'Not configured'}}}    │                                                               │               │
└───────────┴──────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┴───────────────┘
``` 

3. Testcase fail when routes are invalid or inactive
```
 
                                                                                          All tests results                                                                                           
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Device    ┃ Test Name                ┃ Test Status ┃ Message(s)                                                    ┃ Test description                                              ┃ Test category ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ s1-spine1 │ VerifyBGPExchangedRoutes │ failure     │ Following BGP peers are not found or routes are not exchanged │ Verifies if BGP peers have correctly advertised/received      │ routing, bgp  │
│           │                          │             │ properly:                                                     │ routes with type as valid and active for a specified VRF.     │               │
│           │                          │             │ {'bgp_peers': {'172.30.11.1': {'default':                     │                                                               │               │
│           │                          │             │ {'advertised_routes': {'192.0.254.31/32': 'Not found'},       │                                                               │               │
│           │                          │             │ 'received_routes': {'192.0.255.4/32': {'valid': False,        │                                                               │               │
│           │                          │             │ 'active': True}}}}, '172.30.11.5': {'default':                │                                                               │               │
│           │                          │             │ {'advertised_routes': {'192.2.254.31/32': 'Not found'},       │                                                               │               │
│           │                          │             │ 'received_routes': {'192.0.255.41/32': 'Not found'}}}}}       │                                                               │               │
└───────────┴──────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┴───────────────┘
```
Fixes  #482 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
