### PR TITLE
doc: Banner for main being unstable is hidden because of this setting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,6 @@ extra:
     provider: mike
     default:
       - stable
-      - main
 
 extra_css:
   - stylesheets/extra.material.css


### PR DESCRIPTION
# Description

Missa made a bad mkdocs / mike setting and this somehow caught up

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
