### PR TITLE
bump: ANTA v0.12.0

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -26,7 +26,7 @@ $ pip install -e .[dev]
 $ pip list -e
 Package Version Editable project location
 ------- ------- -------------------------
-anta    0.11.0   /mnt/lab/projects/anta
+anta    0.12.0   /mnt/lab/projects/anta
 ```
 
 Then, [`tox`](https://tox.wiki/) is configued with few environments to run CI locally:

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -61,7 +61,7 @@ which anta
 ```bash
 # Check ANTA version
 anta --version
-anta, version v0.11.0
+anta, version v0.12.0
 ```
 
 ## EOS Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anta"
-version = "v0.11.0"
+version = "v0.12.0"
 readme = "docs/README.md"
 authors = [{ name = "Khelil Sator", email = "ksator@arista.com" }]
 maintainers = [
@@ -110,7 +110,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "0.11.0"
+current_version = "0.12.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Changes
* fix(anta.cli)!: Remove confusing -i option in anta get from-ansible by @titom73 in https://github.com/arista-netdevops-community/anta/pull/474
* fix(anta.cli)!: Avoid requiring username, password, inventory for the get commands by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/447
### New features and enhancements
* feat(anta.cli): Show lines between table rows for readability by @paullavelle in https://github.com/arista-netdevops-community/anta/pull/455
* feat: unsupported platform warning by @mtache in https://github.com/arista-netdevops-community/anta/pull/437
* feat: Custom type Interface will format interface name by @mtache in https://github.com/arista-netdevops-community/anta/pull/480
### Fixed issues
* fix(anta): Catalog issues when parsed data has the wrong type by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/462
* fix(anta.tests): Add quotes around version name in VerifyEOSVersion by @titom73 in https://github.com/arista-netdevops-community/anta/pull/471
* fix(anta.cli): Use configured anta inventory as output by default in get from-ansible by @titom73 in https://github.com/arista-netdevops-community/anta/pull/469
* fix: improve various logs by @mtache in https://github.com/arista-netdevops-community/anta/pull/481
### Documentation
* doc: Fix wrong test name by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/464
* doc: Remove BGP deprecated doc by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/477
* doc: Banner for main being unstable is hidden because of this setting by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/485
### Other Changes
* chore: update pydantic requirement from <2.5.0,>=2.1.1 to >=2.1.1,<2.6.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/456
* chore: update rich requirement from <13.7.0,>=13.5.2 to >=13.5.2,<13.8.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/467
* refactor(anta.tests): Remove decorator and deprecated tests by @gmuloc in https://github.com/arista-netdevops-community/anta/pull/473
* chore: bump isort from 5.12.0 to 5.13.1 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/491
* chore: bump black from 23.11.0 to 23.12.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/492
* chore: bump isort from 5.13.1 to 5.13.2 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/494
* chore: bump isort and black in pre-commit by @titom73 in https://github.com/arista-netdevops-community/anta/pull/496
* chore: Add a devcontainer environment for remote development by @titom73 in https://github.com/arista-netdevops-community/anta/pull/497
* chore: bump black from 23.12.0 to 23.12.1 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/502
* chore: bump flake8 from 6.1.0 to 7.0.0 by @dependabot in https://github.com/arista-netdevops-community/anta/pull/511

## New Contributors
* @paullavelle made their first contribution in https://github.com/arista-netdevops-community/anta/pull/455

**Full Changelog**: https://github.com/arista-netdevops-community/anta/compare/v0.11.0...v0.12.0