### PR TITLE
feat(anta.tests): New BGP EVPN Type-2 route test

### DIFF
--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -423,13 +423,13 @@ class VerifyEVPNType2Route(AntaTest):
     categories = ["routing", "bgp"]
     commands = [AntaTemplate(template="show bgp evpn route-type mac-ip {address} vni {vni}")]
 
-    class Input(AntaTest.Input):  # pylint: disable=missing-class-docstring
+    class Input(AntaTest.Input):
         """Inputs for the VerifyEVPNType2Route test."""
 
         vxlan_endpoints: List[VxlanEndpoint]
         """List of VXLAN endpoints to verify"""
 
-        class VxlanEndpoint(BaseModel):  # pylint: disable=missing-class-docstring
+        class VxlanEndpoint(BaseModel):
             """VXLAN endpoint input model."""
 
             address: Union[IPv4Address, MacAddress]

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -310,9 +310,9 @@ anta.tests.routing:
               - 10.1.255.4
     - VerifyEVPNType2Route:
         vxlan_endpoints:
-          - endpoint: 192.168.20.102
+          - address: 192.168.20.102
             vni: 10020
-          - endpoint: aac1.ab5d.b41e
+          - address: aac1.ab5d.b41e
             vni: 10010
   ospf:
     - VerifyOSPFNeighborState:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -308,6 +308,12 @@ anta.tests.routing:
               - 10.1.255.0
               - 10.1.255.2
               - 10.1.255.4
+    - VerifyEVPNType2Route:
+        vxlan_endpoints:
+          - endpoint: 192.168.20.102
+            vni: 10020
+          - endpoint: aac1.ab5d.b41e
+            vni: 10010
   ospf:
     - VerifyOSPFNeighborState:
     - VerifyOSPFNeighborCount:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "click-help-colors~=0.9",
   "cvprac~=1.3.1",
   "pydantic>=2.1.1,<2.6.0",
+  "pydantic-extra-types>=2.1.0",
   "PyYAML~=6.0",
   "requests~=2.31.0",
   "rich>=13.5.2,<13.8.0",

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -18,7 +18,8 @@ from anta.tests.routing.bgp import (  # noqa: E402
     VerifyBGPPeerMPCaps,
     VerifyBGPPeerRouteRefreshCap,
     VerifyBGPPeersHealth,
-    VerifyBGPSpecificPeers, VerifyEVPNType2Route,
+    VerifyBGPSpecificPeers,
+    VerifyEVPNType2Route,
 )
 from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
 

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Arista Networks, Inc.
+# Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """
@@ -11,7 +11,7 @@ from typing import Any
 
 # pylint: disable=C0413
 # because of the patch above
-from anta.tests.routing.bgp import VerifyBGPPeerCount, VerifyBGPPeersHealth, VerifyBGPSpecificPeers  # noqa: E402
+from anta.tests.routing.bgp import VerifyBGPPeerCount, VerifyBGPPeersHealth, VerifyBGPSpecificPeers, VerifyEVPNType2Route  # noqa: E402
 from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
 
 DATA: list[dict[str, Any]] = [
@@ -1237,6 +1237,414 @@ DATA: list[dict[str, Any]] = [
                 "{'afi': 'ipv6', 'safi': 'unicast', 'vrfs': {'default': 'Not Configured'}}, "
                 "{'afi': 'evpn', 'vrfs': {'default': {'10.1.0.2': {'peerState': 'Idle', 'inMsgQueue': 0, 'outMsgQueue': 0}}}"
             ],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            }
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-endpoints",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10010 aac1.ab5d.b41e": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}, {"endpoint": "aac1.ab5d.b41e", "vni": 10010}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-routes-ip",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-routes-mac",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-routes-multiple-paths-ip",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                    "ecmp": True,
+                                    "ecmpContributor": True,
+                                    "ecmpHead": True,
+                                },
+                            },
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": True,
+                                    "ecmp": True,
+                                    "ecmpContributor": True,
+                                    "ecmpHead": False,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-routes-multiple-paths-mac",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                    "ecmp": True,
+                                    "ecmpContributor": True,
+                                    "ecmpHead": True,
+                                },
+                            },
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": True,
+                                    "ecmp": True,
+                                    "ecmpContributor": True,
+                                    "ecmpHead": False,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-no-routes",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [{"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}}],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["The following VXLAN endpoint do not have any EVPN Type-2 route: [('192.168.20.102', 10020)]"],
+        },
+    },
+    {
+        "name": "failure-path-not-active",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following EVPN Type-2 routes do not have at least one valid and active path: ['RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102']"
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-routes-not-active",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following EVPN Type-2 routes do not have at least one valid and active path: "
+                "['RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102', "
+                "'RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102']"
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-endpoints",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10010 aac1.ab5d.b41e": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}, {"endpoint": "aac1.ab5d.b41e", "vni": 10010}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following EVPN Type-2 routes do not have at least one valid and active path: "
+                "['RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102', "
+                "'RD: 10.1.0.5:500 mac-ip 10010 aac1.ab5d.b41e']"
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-endpoints-one-no-routes",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}},
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10010 aac1.ab5d.b41e 192.168.10.101": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}, {"endpoint": "192.168.10.101", "vni": 10010}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following VXLAN endpoint do not have any EVPN Type-2 route: [('aa:c1:ab:4e:be:c2', 10020)]",
+                "The following EVPN Type-2 routes do not have at least one valid and active path: "
+                "['RD: 10.1.0.5:500 mac-ip 10010 aac1.ab5d.b41e 192.168.10.101']",
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-endpoints-no-routes",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}},
+            {"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}},
+        ],
+        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}, {"endpoint": "192.168.10.101", "vni": 10010}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["The following VXLAN endpoint do not have any EVPN Type-2 route: [('aa:c1:ab:4e:be:c2', 10020), ('192.168.10.101', 10010)]"],
         },
     },
 ]

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -1261,7 +1261,7 @@ DATA: list[dict[str, Any]] = [
                 },
             }
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {"result": "success"},
     },
     {
@@ -1303,7 +1303,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}, {"endpoint": "aac1.ab5d.b41e", "vni": 10010}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}, {"address": "aac1.ab5d.b41e", "vni": 10010}]},
         "expected": {"result": "success"},
     },
     {
@@ -1338,7 +1338,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {"result": "success"},
     },
     {
@@ -1373,7 +1373,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "aac1.ab4e.bec2", "vni": 10020}]},
         "expected": {"result": "success"},
     },
     {
@@ -1420,7 +1420,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {"result": "success"},
     },
     {
@@ -1467,14 +1467,14 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "aac1.ab4e.bec2", "vni": 10020}]},
         "expected": {"result": "success"},
     },
     {
         "name": "failure-no-routes",
         "test": VerifyEVPNType2Route,
         "eos_data": [{"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}}],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {
             "result": "failure",
             "messages": ["The following VXLAN endpoint do not have any EVPN Type-2 route: [('192.168.20.102', 10020)]"],
@@ -1502,7 +1502,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {
             "result": "failure",
             "messages": [
@@ -1542,13 +1542,65 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {
             "result": "failure",
             "messages": [
                 "The following EVPN Type-2 routes do not have at least one valid and active path: "
                 "['RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102', "
                 "'RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102']"
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-routes-multiple-paths-not-active",
+        "test": VerifyEVPNType2Route,
+        "eos_data": [
+            {
+                "vrf": "default",
+                "routerId": "10.1.0.3",
+                "asn": 65120,
+                "evpnRoutes": {
+                    "RD: 10.1.0.5:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": True,
+                                    "valid": True,
+                                },
+                            },
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": True,
+                                },
+                            },
+                        ]
+                    },
+                    "RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102": {
+                        "evpnRoutePaths": [
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                            {
+                                "routeType": {
+                                    "active": False,
+                                    "valid": False,
+                                },
+                            },
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following EVPN Type-2 routes do not have at least one valid and active path: ['RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102']"
             ],
         },
     },
@@ -1591,7 +1643,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "192.168.20.102", "vni": 10020}, {"endpoint": "aac1.ab5d.b41e", "vni": 10010}]},
+        "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}, {"address": "aac1.ab5d.b41e", "vni": 10010}]},
         "expected": {
             "result": "failure",
             "messages": [
@@ -1624,7 +1676,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}, {"endpoint": "192.168.10.101", "vni": 10010}]},
+        "inputs": {"vxlan_endpoints": [{"address": "aac1.ab4e.bec2", "vni": 10020}, {"address": "192.168.10.101", "vni": 10010}]},
         "expected": {
             "result": "failure",
             "messages": [
@@ -1641,7 +1693,7 @@ DATA: list[dict[str, Any]] = [
             {"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}},
             {"vrf": "default", "routerId": "10.1.0.3", "asn": 65120, "evpnRoutes": {}},
         ],
-        "inputs": {"vxlan_endpoints": [{"endpoint": "aac1.ab4e.bec2", "vni": 10020}, {"endpoint": "192.168.10.101", "vni": 10010}]},
+        "inputs": {"vxlan_endpoints": [{"address": "aac1.ab4e.bec2", "vni": 10020}, {"address": "192.168.10.101", "vni": 10010}]},
         "expected": {
             "result": "failure",
             "messages": ["The following VXLAN endpoint do not have any EVPN Type-2 route: [('aa:c1:ab:4e:be:c2', 10020), ('192.168.10.101', 10010)]"],


### PR DESCRIPTION
# Description
This test verifies the EVPN Type-2 routes for a given IPv4 or MAC address and VNI.

Expected Results:
    * success: If all provided VXLAN endpoints have at least one valid and active path to their EVPN Type-2 routes.
    * failure: If any of the provided VXLAN endpoints do not have at least one valid and active path to their EVPN Type-2 routes.

- Added new test
- Cleanup old BGP function
- Added new pydantic_extra_types to requirements

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
