### PR TITLE
fix(anta.cli): Allow commands in snapshot to use / and protect filename

### DIFF
--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -11,6 +11,7 @@ import asyncio
 import itertools
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -22,7 +23,7 @@ from anta.inventory import AntaInventory
 from anta.models import AntaCommand
 
 EOS_SCHEDULED_TECH_SUPPORT = "/mnt/flash/schedule/tech-support"
-
+INVALID_CHAR = "`~!@#$/"
 logger = logging.getLogger(__name__)
 
 
@@ -61,16 +62,17 @@ async def collect_commands(
     async def collect(dev: AntaDevice, command: str, outformat: Literal["json", "text"]) -> None:
         outdir = Path() / root_dir / dev.name / outformat
         outdir.mkdir(parents=True, exist_ok=True)
+        safe_command = re.sub(r"(/|\|$)", "_", command)
         c = AntaCommand(command=command, ofmt=outformat)
         await dev.collect(c)
         if not c.collected:
             logger.error(f"Could not collect commands on device {dev.name}: {c.errors}")
             return
         if c.ofmt == "json":
-            outfile = outdir / f"{command}.json"
+            outfile = outdir / f"{safe_command}.json"
             content = json.dumps(c.json_output, indent=2)
         elif c.ofmt == "text":
-            outfile = outdir / f"{command}.log"
+            outfile = outdir / f"{safe_command}.log"
             content = c.text_output
         with outfile.open(mode="w", encoding="UTF-8") as f:
             f.write(content)


### PR DESCRIPTION
# Description

Add protection to allow user to snapshot a command that use invalid character for filename. If an invalid character is found in filename, it is replaced by `_` character.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
