### PR TITLE
fix(anta): get_json_results returns null instead of "None"

### DIFF
--- a/anta/result_manager/__init__.py
+++ b/anta/result_manager/__init__.py
@@ -155,10 +155,8 @@ class ResultManager:
         Returns:
             str: JSON dumps of the list of results
         """
-        res = []
-        for device in self._result_entries:
-            res.append({k: v if isinstance(v, list) else str(v) for k, v in device})
-        return json.dumps(res, indent=4)
+        result = [result.model_dump() for result in self._result_entries]
+        return json.dumps(result, indent=4)
 
     def get_result_by_test(self, test_name: str) -> list[TestResult]:
         """

--- a/tests/lib/fixture.py
+++ b/tests/lib/fixture.py
@@ -121,6 +121,7 @@ def test_result_factory(device: AntaDevice) -> Callable[[int], TestResult]:
             test=f"VerifyTest{index}",
             categories=["test"],
             description=f"Verifies Test {index}",
+            custom_field=None,
         )
 
     return _create

--- a/tests/units/result_manager/test__init__.py
+++ b/tests/units/result_manager/test__init__.py
@@ -184,10 +184,18 @@ class Test_ResultManager:
             test.result = "success"
         result_manager.add_test_results(success_list)
 
-        res = result_manager.get_json_results()
-        assert isinstance(res, str)
-        # verifies it can be loaded as json
-        json.loads(res)
+        json_res = result_manager.get_json_results()
+        assert isinstance(json_res, str)
+
+        # Verifies it can be deserialized back to a list of dict with the correct values types
+        res = json.loads(json_res)
+        for test in res:
+            assert isinstance(test, dict)
+            assert isinstance(test.get("test"), str)
+            assert isinstance(test.get("categories"), list)
+            assert isinstance(test.get("description"), str)
+            assert test.get("custom_field") is None
+            assert test.get("result") == "success"
 
     # TODO
     # get_result_by_test


### PR DESCRIPTION
# Description

`get_json_results` function in `ResultManager` was serializing `None` objects to `'None'` instead of `null`.

It will now use the built-in `model_dump` from Pydantic for proper serialization.

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
