### PR TITLE
feat(anta.tests): Added testcase for MLAG primary priority

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -54,6 +54,7 @@ TestStatus = Literal["unset", "success", "failure", "error", "skipped"]
 # AntaTest.Input types
 AAAAuthMethod = Annotated[str, AfterValidator(aaa_group_prefix)]
 Vlan = Annotated[int, Field(ge=0, le=4094)]
+MlagPriority = Annotated[int, Field(ge=1, le=32767)]
 Vni = Annotated[int, Field(ge=1, le=16777215)]
 Interface = Annotated[
     str,

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -160,6 +160,8 @@ anta.tests.mlag:
       errdisabled: True
       recovery_delay: 60
       recovery_delay_non_mlag: 0
+  - VerifyMlagPrimaryPriority:
+      primary_priority: 3276
 
 anta.tests.multicast:
   - VerifyIGMPSnoopingVlans:

--- a/tests/units/anta_tests/test_mlag.py
+++ b/tests/units/anta_tests/test_mlag.py
@@ -322,10 +322,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"primary_priority": 32767},
         "expected": {
             "result": "failure",
-            "messages": [
-                "The device is not set as the MLAG primary or the primary priority does not match the expected value:\n"
-                "Expected `primary` as the mlagState, but found `secondary` instead."
-            ],
+            "messages": ["The device is not set as MLAG primary."],
         },
     },
     {
@@ -340,10 +337,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"primary_priority": 1},
         "expected": {
             "result": "failure",
-            "messages": [
-                "The device is not set as the MLAG primary or the primary priority does not match the expected value:\n"
-                "Expected `primary` as the mlagState, but found `secondary` instead.\nExpected `1` as the primaryPriority, but found `32767` instead."
-            ],
+            "messages": ["The device is not set as MLAG primary.", "The primary priority does not match expected. Expected `1`, but found `32767` instead."],
         },
     },
 ]


### PR DESCRIPTION
# Description

Added testcase for MLAG primary priority

Fixes #529 
Success: The test will pass if the MLAG state is set as 'primary' and the priority matches the input.
Failure: The test will fail if the MLAG state is not 'primary' or the priority doesn't match the input.
Skipped: The test will be skipped if MLAG is 'disabled'.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
