### PR TITLE
feat(anta.tests): Added testcase to verify errordisable recovery reason

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -91,3 +91,18 @@ EncryptionAlgorithm = Literal["RSA", "ECDSA"]
 RsaKeySize = Literal[2048, 3072, 4096]
 EcdsaKeySize = Literal[256, 384, 521]
 MultiProtocolCaps = Annotated[str, BeforeValidator(bgp_multiprotocol_capabilities_abbreviations)]
+ErrorDisableReasons = Literal[
+    "acl",
+    "arp-inspection",
+    "bpduguard",
+    "dot1x-session-replace",
+    "hitless-reload-down",
+    "lacp-rate-limit",
+    "link-flap",
+    "no-internal-vlan",
+    "portchannelguard",
+    "portsec",
+    "tapagg",
+    "uplink-failure-detection",
+]
+ErrDisableInterval = Annotated[int, Field(ge=30, le=86400)]

--- a/anta/tests/services.py
+++ b/anta/tests/services.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""
+Test functions related to the EOS various service settings
+"""
+
+# Mypy does not understand AntaTest.Input typing
+# mypy: disable-error-code=attr-defined
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+from anta.custom_types import ErrDisableInterval, ErrorDisableReasons
+from anta.models import AntaCommand, AntaTest
+from anta.tools.utils import get_failed_logs
+
+
+class VerifyErrdisableRecovery(AntaTest):
+    """
+    This class verifies the error-disable recovery reason, status, and interval.
+
+    Expected Results:
+        * Success: The test will pass if the error-disable recovery reason status is enabled and the interval matches the input.
+        * Failure: The test will fail if the error-disable recovery reason is not found, the status is not enabled, or the interval does not match the input.
+    """
+
+    name = "VerifyErrdisableRecovery"
+    description = "Verifies the error-disable recovery reason, status, and interval."
+    categories = ["services"]
+    commands = [AntaCommand(command="show errdisable recovery", ofmt="text")]  # Command dose not support JSON output hence using text output
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifyErrdisableRecovery test."""
+
+        reasons: List[ErrDisableReasons]
+        """List of error-disable reasons"""
+
+        class ErrDisableReasons(BaseModel):
+            """Details of an error-disable reason"""
+
+            reason: ErrorDisableReasons
+            """Type or name of the error-disable reason"""
+            interval: ErrDisableInterval
+            """Interval of the reason in seconds"""
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        command_output = self.instance_commands[0].text_output
+        self.result.is_success()
+        for error_reason in self.inputs.reasons:
+            input_reason = error_reason.reason
+            input_interval = error_reason.interval
+            reason_found = False
+
+            # Skip header and last empty line
+            lines = command_output.split("\n")[2:-1]
+            for line in lines:
+                # Skip empty lines
+                if not line.strip():
+                    continue
+                # Split by first two whitespaces
+                reason, status, interval = line.split(None, 2)
+                if reason != input_reason:
+                    continue
+                reason_found = True
+                actual_reason_data = {"interval": interval, "status": status}
+                expected_reason_data = {"interval": str(input_interval), "status": "Enabled"}
+                if actual_reason_data != expected_reason_data:
+                    failed_log = get_failed_logs(expected_reason_data, actual_reason_data)
+                    self.result.is_failure(f"`{input_reason}`:{failed_log}\n")
+                break
+
+            if not reason_found:
+                self.result.is_failure(f"`{input_reason}`: Not found.\n")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -206,6 +206,14 @@ anta.tests.security:
           encryption_algorithm: RSA
           key_size: 4096
 
+anta.tests.services:
+  - VerifyErrdisableRecovery:
+      reasons:
+        - reason: acl
+          interval: 30
+        - reason: bpduguard
+          interval: 30
+
 anta.tests.snmp:
   - VerifySnmpStatus:
       vrf: default

--- a/tests/units/anta_tests/test_services.py
+++ b/tests/units/anta_tests/test_services.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""
+Tests for anta.tests.security.py
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from anta.tests.services import VerifyErrdisableRecovery
+from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
+
+DATA: list[dict[str, Any]] = [
+    {
+        "name": "success",
+        "test": VerifyErrdisableRecovery,
+        "eos_data": [
+            """
+                Errdisable Reason              Timer Status   Timer Interval
+                ------------------------------ ----------------- --------------
+                acl                            Enabled                  300
+                bpduguard                      Enabled                  300
+                arp-inspection                 Enabled                  30
+            """
+        ],
+        "inputs": {"reasons": [{"reason": "acl", "interval": 300}, {"reason": "bpduguard", "interval": 300}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-reason-missing",
+        "test": VerifyErrdisableRecovery,
+        "eos_data": [
+            """
+                Errdisable Reason              Timer Status   Timer Interval
+                ------------------------------ ----------------- --------------
+                acl                            Enabled                  300
+                bpduguard                      Enabled                  300
+                arp-inspection                 Enabled                  30
+            """
+        ],
+        "inputs": {"reasons": [{"reason": "acl", "interval": 300}, {"reason": "arp-inspection", "interval": 30}, {"reason": "tapagg", "interval": 30}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["`tapagg`: Not found."],
+        },
+    },
+    {
+        "name": "failure-reason-disabled",
+        "test": VerifyErrdisableRecovery,
+        "eos_data": [
+            """
+                Errdisable Reason              Timer Status   Timer Interval
+                ------------------------------ ----------------- --------------
+                acl                            Disabled                 300
+                bpduguard                      Enabled                  300
+                arp-inspection                 Enabled                  30
+            """
+        ],
+        "inputs": {"reasons": [{"reason": "acl", "interval": 300}, {"reason": "arp-inspection", "interval": 30}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["`acl`:\nExpected `Enabled` as the status, but found `Disabled` instead."],
+        },
+    },
+    {
+        "name": "failure-interval-not-ok",
+        "test": VerifyErrdisableRecovery,
+        "eos_data": [
+            """
+                Errdisable Reason              Timer Status   Timer Interval
+                ------------------------------ ----------------- --------------
+                acl                            Enabled                  300
+                bpduguard                      Enabled                  300
+                arp-inspection                 Enabled                  30
+            """
+        ],
+        "inputs": {"reasons": [{"reason": "acl", "interval": 30}, {"reason": "arp-inspection", "interval": 30}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["`acl`:\nExpected `30` as the interval, but found `300` instead."],
+        },
+    },
+    {
+        "name": "failure-all-type",
+        "test": VerifyErrdisableRecovery,
+        "eos_data": [
+            """
+                Errdisable Reason              Timer Status   Timer Interval
+                ------------------------------ ----------------- --------------
+                acl                            Disabled                 300
+                bpduguard                      Enabled                  300
+                arp-inspection                 Enabled                  30
+            """
+        ],
+        "inputs": {"reasons": [{"reason": "acl", "interval": 30}, {"reason": "arp-inspection", "interval": 300}, {"reason": "tapagg", "interval": 30}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "`acl`:\nExpected `30` as the interval, but found `300` instead.\nExpected `Enabled` as the status, but found `Disabled` instead.",
+                "`arp-inspection`:\nExpected `300` as the interval, but found `30` instead.",
+                "`tapagg`: Not found.",
+            ],
+        },
+    },
+]


### PR DESCRIPTION
# Description

Added testcase to verify errordisable recovery reason.

```
    Verifies the error-disable recovery reason, status, and interval.

    Expected Results:
        * Success: The test will pass if the error-disable recovery reason status is enabled and the interval matches the input.
        * Failure: The test will fail if the error-disable recovery reason is not found, the status is not enabled, or the interval does not match the input.
```

Fixes #538 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
