### PR TITLE
feat(anta.tests): Added testcase to verify IPv4 ACL sequence entries

### DIFF
--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -14,7 +14,8 @@ from typing import List, Union
 from pydantic import BaseModel, conint, model_validator
 
 from anta.custom_types import EcdsaKeySize, EncryptionAlgorithm, RsaKeySize
-from anta.models import AntaCommand, AntaTest
+from anta.models import AntaCommand, AntaTemplate, AntaTest
+from anta.tools.get_item import get_item
 from anta.tools.get_value import get_value
 from anta.tools.utils import get_failed_logs
 
@@ -377,3 +378,73 @@ class VerifyAPISSLCertificate(AntaTest):
                 failed_log = f"SSL certificate `{certificate.certificate_name}` is not configured properly:"
                 failed_log += get_failed_logs(expected_certificate_details, actual_certificate_details)
                 self.result.is_failure(f"{failed_log}\n")
+
+
+class VerifyIpv4ACL(AntaTest):
+    """
+    This class verifies the configuration and the correct operation of the IPv4 access lists.
+
+    Expected results:
+        * success: The test will pass if an IPv4 ACL is configured with the correct sequence entries.
+        * failure: The test will fail if an IPv4 ACL is not configured or entries are not in sequence.
+    """
+
+    name = "VerifyIpv4ACL"
+    description = "Verifies the configuration and the correct operation of the IPv4 access lists."
+    categories = ["security"]
+    commands = [AntaTemplate(template="show ip access-lists {acl}")]
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifyIpv4ACL test."""
+
+        ipv4_access_list: List[Ipv4Acl]
+        """List of IPv4 ACL to verify"""
+
+        class Ipv4Acl(BaseModel):
+            """Detail of IPv4 ACl"""
+
+            name: str
+            """Name of IPv4 ACL"""
+
+            entries: List[Ipv4AclEntries]
+            """List of IPv4 ACL entries"""
+
+            class Ipv4AclEntries(BaseModel):
+                """IPv4 ACL entries details"""
+
+                sequence: int
+                """Sequence number of ACL entry"""
+                action: str
+                """Action of an ACL entry"""
+
+    def render(self, template: AntaTemplate) -> list[AntaCommand]:
+        return [template.render(acl=acl.name, entries=acl.entries) for acl in self.inputs.ipv4_access_list]
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        self.result.is_success()
+        for command_output in self.instance_commands:
+            # Collecting input ACL details
+            acl_name = command_output.params["acl"]
+            acl_entries = command_output.params["entries"]
+
+            # Check if ACL is configured
+            ipv4_acl_list = command_output.json_output["aclList"]
+            if not ipv4_acl_list:
+                self.result.is_failure(f"{acl_name}: Not found")
+                continue
+
+            # Check if the sequence number is configured and has the correct action applied
+            failed_log = f"{acl_name}:\n"
+            for acl_entry in acl_entries:
+                acl_seq = acl_entry.sequence
+                acl_action = acl_entry.action
+                if (actual_entry := get_item(ipv4_acl_list[0]["sequence"], "sequenceNumber", acl_seq)) is None:
+                    failed_log += f"Sequence number `{acl_seq}` is not found.\n"
+                    continue
+
+                if actual_entry["text"] != acl_action:
+                    failed_log += f"Expected `{acl_action}` as sequence number {acl_seq} action but found `{actual_entry['text']}` instead.\n"
+
+            if failed_log != f"{acl_name}:\n":
+                self.result.is_failure(f"{failed_log}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -205,6 +205,22 @@ anta.tests.security:
           common_name: Arista Networks Internal IT Root Cert Authority
           encryption_algorithm: RSA
           key_size: 4096
+  - VerifyIpv4ACL:
+      ipv4_access_list:
+        - name: default-control-plane-acl
+          entries:
+            - sequence: 10
+              action: permit icmp any any
+            - sequence: 20
+              action: permit ip any any tracked
+            - sequence: 30
+              action: permit udp any any eq bfd ttl eq 255
+        - name: LabTest
+          entries:
+            - sequence: 10
+              action: permit icmp any any
+            - sequence: 20
+              action: permit tcp any any range 5900 5910
 
 anta.tests.snmp:
   - VerifySnmpStatus:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -229,7 +229,17 @@ anta.tests.security:
           common_name: Arista Networks Internal IT Root Cert Authority
           encryption_algorithm: RSA
           key_size: 4096
-  - VerifyIpv4ACL:
+  - VerifyBannerLogin:
+        login_banner: |
+            # Copyright (c) 2023-2024 Arista Networks, Inc.
+            # Use of this source code is governed by the Apache License 2.0
+            # that can be found in the LICENSE file.
+  - VerifyBannerMotd:
+        motd_banner: |
+            # Copyright (c) 2023-2024 Arista Networks, Inc.
+            # Use of this source code is governed by the Apache License 2.0
+            # that can be found in the LICENSE file.
+  - VerifyIPv4ACL:
       ipv4_access_lists:
         - name: default-control-plane-acl
           entries:
@@ -247,16 +257,6 @@ anta.tests.security:
               action: permit tcp any any range 5900 5910
 
 anta.tests.services:
-  - VerifyBannerLogin:
-        login_banner: |
-            # Copyright (c) 2023-2024 Arista Networks, Inc.
-            # Use of this source code is governed by the Apache License 2.0
-            # that can be found in the LICENSE file.
-  - VerifyBannerMotd:
-        motd_banner: |
-            # Copyright (c) 2023-2024 Arista Networks, Inc.
-            # Use of this source code is governed by the Apache License 2.0
-            # that can be found in the LICENSE file.
   - VerifyHostname:
       hostname: s1-spine1
   - VerifyDNSLookup:
@@ -355,7 +355,6 @@ anta.tests.routing:
     - VerifyRoutingTableSize:
         minimum: 2
         maximum: 20
-    - VerifyBFD:
     - VerifyRoutingTableEntry:
         vrf: default
         routes:


### PR DESCRIPTION
# Description

Added testcase to verify IPv4 ACL sequence entries. 

Note: This test only check if a acl is configured and input entries sequence are same in actual output. It will not fail if we have 2 entries of a acl in input but in actual output there are more then 2 entries. If input two entries sequence is match with actual output then testcase will pass. @carl-baillargeon 

```
Expected results:
        * success: The test will pass if an IPv4 ACL is configured with the correct sequence entries.
        * failure: The test will fail if an IPv4 ACL is not configured or entries are not in sequence.
```

Fixes #543 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
