### PR TITLE
feat(anta.tests): Added testcase to verify ip address on interface

### DIFF
--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -12,7 +12,7 @@ import re
 from ipaddress import IPv4Network
 
 # Need to keep Dict and List for pydantic in python 3.8
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, conint
 
@@ -444,6 +444,7 @@ class VerifyL2MTU(AntaTest):
 class VerifyInterfaceIPv4(AntaTest):
     """
     This class verifies if an interface is configured with a correct primary and secondary IPv4 address.
+    Secondary IPv4 address verification is optional.
 
     Expected Results:
         * success: The test will pass if an interface is configured with a correct primary and secondary IPv4 address.
@@ -451,31 +452,30 @@ class VerifyInterfaceIPv4(AntaTest):
     """
 
     name = "VerifyInterfaceIPv4"
-    description = "Verifies if an interface is configured with a correct primary and secondary IPv4 address"
+    description = "Verifies if an interface is configured with a correct primary and secondary IPv4 address."
     categories = ["interfaces"]
     commands = [AntaTemplate(template="show ip interface {interface}")]
 
     class Input(AntaTest.Input):
         """Inputs for the VerifyInterfaceIPv4 test."""
 
-        interfaces: List[Interfaces]
+        interfaces: List[InterfaceDetail]
         """list of interfaces to be tested"""
 
-        class Interfaces(BaseModel):
+        class InterfaceDetail(BaseModel):
             """Detail of an interface"""
 
-            interface: Interface
+            name: Interface
             """Name of the interface"""
             primary_ip: IPv4Network
             """Primary IPv4 network on interface"""
-            secondary_ips: List[IPv4Network]
-            """List of secondary IPv4 networks on interface"""
+            secondary_ips: Optional[List[IPv4Network]] = None
+            """Optional list of secondary IPv4 networks on interface"""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:
         # Render the template for each interface
         return [
-            template.render(interface=interface.interface, primary_ip=interface.primary_ip, secondary_ips=interface.secondary_ips)
-            for interface in self.inputs.interfaces
+            template.render(interface=interface.name, primary_ip=interface.primary_ip, secondary_ips=interface.secondary_ips) for interface in self.inputs.interfaces
         ]
 
     @AntaTest.anta_test
@@ -484,26 +484,40 @@ class VerifyInterfaceIPv4(AntaTest):
         for command in self.instance_commands:
             intf = command.params["interface"]
             input_primary_ip = str(command.params["primary_ip"])
-            input_secondary_ips = sorted([str(net) for net in command.params["secondary_ips"]])
+            failed_messages = []
 
             # Check if the interface has an IP address configured
-            if not (interface_output := get_value(command.json_output, f"interfaces..{intf}..interfaceAddress", separator="..")):
-                self.result.is_failure(f"IP address is not configured on interface `{intf}`.")
+            if not (interface_output := get_value(command.json_output, f"interfaces.{intf}.interfaceAddress")):
+                self.result.is_failure(f"For interface `{intf}`, IP address is not configured.")
                 continue
 
             primary_ip = get_value(interface_output, "primaryIp")
-            secondary_ips = get_value(interface_output, "secondaryIpsOrderedList")
 
             # Combine IP address and subnet for primary IP
             actual_primary_ip = f"{primary_ip['address']}/{primary_ip['maskLen']}"
 
             # Check if the primary IP address matches the input
             if actual_primary_ip != input_primary_ip:
-                self.result.is_failure(f"For interface {intf} expected primary IP address is {input_primary_ip} but found {actual_primary_ip} instead.")
+                failed_messages.append(f"The expected primary IP address is `{input_primary_ip}`, but the actual primary IP address is `{actual_primary_ip}`.")
 
-            # Combine IP address and subnet for secondary IPs
-            actual_secondary_ips = sorted([f"{secondary_ip['address']}/{secondary_ip['maskLen']}" for secondary_ip in secondary_ips])
+            if command.params["secondary_ips"] is not None:
+                input_secondary_ips = sorted([str(network) for network in command.params["secondary_ips"]])
+                secondary_ips = get_value(interface_output, "secondaryIpsOrderedList")
 
-            # Check if the secondary IP addresses match the input
-            if actual_secondary_ips != input_secondary_ips:
-                self.result.is_failure(f"For interface {intf} expected secondary IP addresses are {input_secondary_ips} but found {actual_secondary_ips} instead.")
+                # Combine IP address and subnet for secondary IPs
+                actual_secondary_ips = sorted([f"{secondary_ip['address']}/{secondary_ip['maskLen']}" for secondary_ip in secondary_ips])
+
+                # Check if the secondary IP address is configured
+                if not actual_secondary_ips:
+                    failed_messages.append(
+                        f"The expected secondary IP addresses are `{input_secondary_ips}`, but the actual secondary IP address is not configured."
+                    )
+
+                # Check if the secondary IP addresses match the input
+                elif actual_secondary_ips != input_secondary_ips:
+                    failed_messages.append(
+                        f"The expected secondary IP addresses are `{input_secondary_ips}`, but the actual secondary IP addresses are `{actual_secondary_ips}`."
+                    )
+
+            if failed_messages:
+                self.result.is_failure(f"For interface `{intf}`, " + " ".join(failed_messages))

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -9,6 +9,7 @@ Test functions related to the device interfaces
 from __future__ import annotations
 
 import re
+from ipaddress import IPv4Network
 
 # Need to keep Dict and List for pydantic in python 3.8
 from typing import Any, Dict, List, Literal
@@ -438,3 +439,71 @@ class VerifyL2MTU(AntaTest):
             self.result.is_failure(f"Some L2 interfaces do not have correct MTU configured:\n{wrong_l2mtu_intf}")
         else:
             self.result.is_success()
+
+
+class VerifyInterfaceIPv4(AntaTest):
+    """
+    This class verifies if an interface is configured with a correct primary and secondary IPv4 address.
+
+    Expected Results:
+        * success: The test will pass if an interface is configured with a correct primary and secondary IPv4 address.
+        * failure: The test will fail if an interface is not found or the primary and secondary IPv4 addresses do not match with the input.
+    """
+
+    name = "VerifyInterfaceIPv4"
+    description = "Verifies if an interface is configured with a correct primary and secondary IPv4 address"
+    categories = ["interfaces"]
+    commands = [AntaTemplate(template="show ip interface {interface}")]
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifyInterfaceIPv4 test."""
+
+        interfaces: List[Interfaces]
+        """list of interfaces to be tested"""
+
+        class Interfaces(BaseModel):
+            """Detail of an interface"""
+
+            interface: Interface
+            """Name of the interface"""
+            primary_ip: IPv4Network
+            """Primary IPv4 network on interface"""
+            secondary_ips: List[IPv4Network]
+            """List of secondary IPv4 networks on interface"""
+
+    def render(self, template: AntaTemplate) -> list[AntaCommand]:
+        # Render the template for each interface
+        return [
+            template.render(interface=interface.interface, primary_ip=interface.primary_ip, secondary_ips=interface.secondary_ips)
+            for interface in self.inputs.interfaces
+        ]
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        self.result.is_success()
+        for command in self.instance_commands:
+            intf = command.params["interface"]
+            input_primary_ip = str(command.params["primary_ip"])
+            input_secondary_ips = sorted([str(net) for net in command.params["secondary_ips"]])
+
+            # Check if the interface has an IP address configured
+            if not (interface_output := get_value(command.json_output, f"interfaces..{intf}..interfaceAddress", separator="..")):
+                self.result.is_failure(f"IP address is not configured on interface `{intf}`.")
+                continue
+
+            primary_ip = get_value(interface_output, "primaryIp")
+            secondary_ips = get_value(interface_output, "secondaryIpsOrderedList")
+
+            # Combine IP address and subnet for primary IP
+            actual_primary_ip = f"{primary_ip['address']}/{primary_ip['maskLen']}"
+
+            # Check if the primary IP address matches the input
+            if actual_primary_ip != input_primary_ip:
+                self.result.is_failure(f"For interface {intf} expected primary IP address is {input_primary_ip} but found {actual_primary_ip} instead.")
+
+            # Combine IP address and subnet for secondary IPs
+            actual_secondary_ips = sorted([f"{secondary_ip['address']}/{secondary_ip['maskLen']}" for secondary_ip in secondary_ips])
+
+            # Check if the secondary IP addresses match the input
+            if actual_secondary_ips != input_secondary_ips:
+                self.result.is_failure(f"For interface {intf} expected secondary IP addresses are {input_secondary_ips} but found {actual_secondary_ips} instead.")

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -443,8 +443,7 @@ class VerifyL2MTU(AntaTest):
 
 class VerifyInterfaceIPv4(AntaTest):
     """
-    This class verifies if an interface is configured with a correct primary and secondary IPv4 address.
-    Secondary IPv4 address verification is optional.
+    Verifies if an interface is configured with a correct primary and list of optional secondary IPv4 addresses.
 
     Expected Results:
         * success: The test will pass if an interface is configured with a correct primary and secondary IPv4 address.
@@ -452,7 +451,7 @@ class VerifyInterfaceIPv4(AntaTest):
     """
 
     name = "VerifyInterfaceIPv4"
-    description = "Verifies if an interface is configured with a correct primary and secondary IPv4 address."
+    description = "Verifies the interface IPv4 addresses."
     categories = ["interfaces"]
     commands = [AntaTemplate(template="show ip interface {interface}")]
 
@@ -468,9 +467,9 @@ class VerifyInterfaceIPv4(AntaTest):
             name: Interface
             """Name of the interface"""
             primary_ip: IPv4Network
-            """Primary IPv4 network on interface"""
+            """Primary IPv4 address with subnet on interface"""
             secondary_ips: Optional[List[IPv4Network]] = None
-            """Optional list of secondary IPv4 networks on interface"""
+            """Optional list of secondary IPv4 addresses with subnet on interface"""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:
         # Render the template for each interface

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -133,7 +133,7 @@ anta.tests.interfaces:
         - Ethernet1/1: 1500
   - VerifyInterfaceIPv4:
       interfaces:
-        - interface: Ethernet2
+        - name: Ethernet2
           primary_ip: 172.30.11.0/31
           secondary_ips:
             - 10.10.10.0/31

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -131,6 +131,13 @@ anta.tests.interfaces:
         - Vxlan1
       specific_mtu:
         - Ethernet1/1: 1500
+  - VerifyInterfaceIPv4:
+      interfaces:
+        - interface: Ethernet2
+          primary_ip: 172.30.11.0/31
+          secondary_ips:
+            - 10.10.10.0/31
+            - 10.10.10.10/31
 
 anta.tests.logging:
   - VerifyLoggingPersistent:

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -1088,8 +1088,41 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         ],
         "inputs": {
             "interfaces": [
-                {"interface": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
-                {"interface": "Ethernet12", "primary_ip": "172.30.11.10/31", "secondary_ips": ["10.10.10.10/31", "10.10.10.20/31"]},
+                {"name": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
+                {"name": "Ethernet12", "primary_ip": "172.30.11.10/31", "secondary_ips": ["10.10.10.10/31", "10.10.10.20/31"]},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-without-secondary-ip",
+        "test": VerifyInterfaceIPv4,
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet2": {
+                        "interfaceAddress": {
+                            "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
+                            "secondaryIpsOrderedList": [],
+                        }
+                    }
+                }
+            },
+            {
+                "interfaces": {
+                    "Ethernet12": {
+                        "interfaceAddress": {
+                            "primaryIp": {"address": "172.30.11.10", "maskLen": 31},
+                            "secondaryIpsOrderedList": [],
+                        }
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet2", "primary_ip": "172.30.11.0/31"},
+                {"name": "Ethernet12", "primary_ip": "172.30.11.10/31"},
             ]
         },
         "expected": {"result": "success"},
@@ -1100,13 +1133,13 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         "eos_data": [{"interfaces": {"Ethernet2": {"interfaceAddress": {}}}}, {"interfaces": {"Ethernet12": {"interfaceAddress": {}}}}],
         "inputs": {
             "interfaces": [
-                {"interface": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
-                {"interface": "Ethernet12", "primary_ip": "172.30.11.20/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
+                {"name": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
+                {"name": "Ethernet12", "primary_ip": "172.30.11.20/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": ["IP address is not configured on interface `Ethernet2`.", "IP address is not configured on interface `Ethernet12`."],
+            "messages": ["For interface `Ethernet2`, IP address is not configured.", "For interface `Ethernet12`, IP address is not configured."],
         },
     },
     {
@@ -1136,17 +1169,17 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         ],
         "inputs": {
             "interfaces": [
-                {"interface": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
-                {"interface": "Ethernet12", "primary_ip": "172.30.11.10/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
+                {"name": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
+                {"name": "Ethernet12", "primary_ip": "172.30.11.10/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
             ]
         },
         "expected": {
             "result": "failure",
             "messages": [
-                "For interface Ethernet2 expected primary IP address is 172.30.11.0/31 but found 0.0.0.0/0 instead.",
-                "For interface Ethernet2 expected secondary IP addresses are ['10.10.10.0/31', '10.10.10.10/31'] but found [] instead.",
-                "For interface Ethernet12 expected primary IP address is 172.30.11.10/31 but found 0.0.0.0/0 instead.",
-                "For interface Ethernet12 expected secondary IP addresses are ['10.10.11.0/31', '10.10.11.10/31'] but found [] instead.",
+                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.0/31`, but the actual primary IP address is `0.0.0.0/0`. "
+                "The expected secondary IP addresses are `['10.10.10.0/31', '10.10.10.10/31']`, but the actual secondary IP address is not configured.",
+                "For interface `Ethernet12`, The expected primary IP address is `172.30.11.10/31`, but the actual primary IP address is `0.0.0.0/0`. "
+                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP address is not configured.",
             ],
         },
     },
@@ -1177,19 +1210,61 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         ],
         "inputs": {
             "interfaces": [
-                {"interface": "Ethernet2", "primary_ip": "172.30.11.2/31", "secondary_ips": ["10.10.10.20/31", "10.10.10.30/31"]},
-                {"interface": "Ethernet3", "primary_ip": "172.30.10.2/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
+                {"name": "Ethernet2", "primary_ip": "172.30.11.2/31", "secondary_ips": ["10.10.10.20/31", "10.10.10.30/31"]},
+                {"name": "Ethernet3", "primary_ip": "172.30.10.2/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
             ]
         },
         "expected": {
             "result": "failure",
             "messages": [
-                "For interface Ethernet2 expected primary IP address is 172.30.11.2/31 but found 172.30.11.0/31 instead.",
-                "For interface Ethernet2 expected secondary IP addresses are ['10.10.10.20/31', '10.10.10.30/31'] but found "
-                "['10.10.10.0/31', '10.10.10.10/31'] instead.",
-                "For interface Ethernet3 expected primary IP address is 172.30.10.2/31 but found 172.30.10.10/31 instead.",
-                "For interface Ethernet3 expected secondary IP addresses are ['10.10.11.0/31', '10.10.11.10/31'] but found "
-                "['10.10.11.0/31', '10.11.11.10/31'] instead.",
+                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.2/31`, but the actual primary IP address is `172.30.11.0/31`. "
+                "The expected secondary IP addresses are `['10.10.10.20/31', '10.10.10.30/31']`, but the actual secondary IP addresses are "
+                "`['10.10.10.0/31', '10.10.10.10/31']`.",
+                "For interface `Ethernet3`, The expected primary IP address is `172.30.10.2/31`, but the actual primary IP address is `172.30.10.10/31`. "
+                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP addresses are "
+                "`['10.10.11.0/31', '10.11.11.10/31']`.",
+            ],
+        },
+    },
+    {
+        "name": "failure-secondary-ip-address",
+        "test": VerifyInterfaceIPv4,
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet2": {
+                        "interfaceAddress": {
+                            "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
+                            "secondaryIpsOrderedList": [],
+                        }
+                    }
+                }
+            },
+            {
+                "interfaces": {
+                    "Ethernet3": {
+                        "interfaceAddress": {
+                            "primaryIp": {"address": "172.30.10.10", "maskLen": 31},
+                            "secondaryIpsOrderedList": [{"address": "10.10.11.0", "maskLen": 31}, {"address": "10.11.11.10", "maskLen": 31}],
+                        }
+                    }
+                }
+            },
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet2", "primary_ip": "172.30.11.2/31", "secondary_ips": ["10.10.10.20/31", "10.10.10.30/31"]},
+                {"name": "Ethernet3", "primary_ip": "172.30.10.2/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.2/31`, but the actual primary IP address is `172.30.11.0/31`. "
+                "The expected secondary IP addresses are `['10.10.10.20/31', '10.10.10.30/31']`, but the actual secondary IP address is not configured.",
+                "For interface `Ethernet3`, The expected primary IP address is `172.30.10.2/31`, but the actual primary IP address is `172.30.10.10/31`. "
+                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP addresses are "
+                "`['10.10.11.0/31', '10.11.11.10/31']`.",
             ],
         },
     },


### PR DESCRIPTION
# Description

Added testcase to verify ip address(primary and secondary) on interface.

Fixes #545 

Expected Results:
        * success: The test will pass if an interface is configured with a correct primary and secondary IPv4 address.
        * failure: The test will fail if an interface is not found or the primary and secondary IPv4 addresses do not match with the input.

Note: There is no optional input. All the input is required and restricted with values. 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
