### PR TITLE
feat(anta.tests): Added testcase to verify vxlan1 source interface and udp port

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -23,16 +23,20 @@ def interface_autocomplete(v: str) -> str:
 
     Supported alias:
          - `et`, `eth` will be changed to `Ethernet`
-         - `po` will be changed to `Port-Channel`"""
+         - `po` will be changed to `Port-Channel`
+         - `lo`, `lb` will be changed to `Loopback`"""
     intf_id_re = re.compile(r"[0-9]+(\/[0-9]+)*(\.[0-9]+)?")
     m = intf_id_re.search(v)
     if m is None:
         raise ValueError(f"Could not parse interface ID in interface '{v}'")
     intf_id = m[0]
-    if any(v.lower().startswith(p) for p in ["et", "eth"]):
-        return f"Ethernet{intf_id}"
-    if v.lower().startswith("po"):
-        return f"Port-Channel{intf_id}"
+
+    alias_map = {"et": "Ethernet", "eth": "Ethernet", "po": "Port-Channel", "lo": "Loopback", "lb": "Loopback"}
+
+    for alias, full_name in alias_map.items():
+        if v.lower().startswith(alias):
+            return f"{full_name}{intf_id}"
+
     return v
 
 
@@ -42,6 +46,7 @@ def interface_case_sensitivity(v: str) -> str:
     Examples:
          - ethernet -> Ethernet
          - vlan -> Vlan
+         - loopback -> Loopback
     """
     if isinstance(v, str) and len(v) > 0 and not v[0].isupper():
         return f"{v[0].upper()}{v[1:]}"
@@ -87,7 +92,7 @@ Interface = Annotated[
 ]
 VxlanSrcIntf = Annotated[
     str,
-    Field(pattern=r"^(Loopback)[0-9]+$"),
+    Field(pattern=r"^(Loopback)([0-9]|[1-9][0-9]{1,2}|[1-7][0-9]{3}|8[01][0-9]{2}|819[01])$"),
     BeforeValidator(interface_autocomplete),
     BeforeValidator(interface_case_sensitivity),
 ]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -85,6 +85,12 @@ Interface = Annotated[
     BeforeValidator(interface_autocomplete),
     BeforeValidator(interface_case_sensitivity),
 ]
+VxlanSrcIntf = Annotated[
+    str,
+    Field(pattern=r"^(Loopback)[0-9]+$"),
+    BeforeValidator(interface_autocomplete),
+    BeforeValidator(interface_case_sensitivity),
+]
 Afi = Literal["ipv4", "ipv6", "vpn-ipv4", "vpn-ipv6", "evpn", "rt-membership"]
 Safi = Literal["unicast", "multicast", "labeled-unicast"]
 EncryptionAlgorithm = Literal["RSA", "ECDSA"]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -24,14 +24,14 @@ def interface_autocomplete(v: str) -> str:
     Supported alias:
          - `et`, `eth` will be changed to `Ethernet`
          - `po` will be changed to `Port-Channel`
-         - `lo`, `lb` will be changed to `Loopback`"""
+         - `lo` will be changed to `Loopback`"""
     intf_id_re = re.compile(r"[0-9]+(\/[0-9]+)*(\.[0-9]+)?")
     m = intf_id_re.search(v)
     if m is None:
         raise ValueError(f"Could not parse interface ID in interface '{v}'")
     intf_id = m[0]
 
-    alias_map = {"et": "Ethernet", "eth": "Ethernet", "po": "Port-Channel", "lo": "Loopback", "lb": "Loopback"}
+    alias_map = {"et": "Ethernet", "eth": "Ethernet", "po": "Port-Channel", "lo": "Loopback"}
 
     for alias, full_name in alias_map.items():
         if v.lower().startswith(alias):

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -177,16 +177,16 @@ class VerifyVxlanVtep(AntaTest):
 
 class VerifyVxlan1ConnSettings(AntaTest):
     """
-    Verifies the VXLAN source interface and UDP port.
+    Verifies the interface vxlan1 source interface and UDP port.
 
     Expected Results:
-      * success: Passes if VXLAN source interface and UDP port are correct.
-      * failure: Fails if VXLAN source interface or UDP port are incorrect.
+      * success: Passes if the interface vxlan1 source interface and UDP port are correct.
+      * failure: Fails if the interface vxlan1 source interface or UDP port are incorrect.
       * skipped: Skips if the Vxlan1 interface is not configured.
     """
 
     name = "VerifyVxlan1ConnSettings"
-    description = "Verifies the VXLAN source interface and UDP port"
+    description = "Verifies the interface vxlan1 source interface and UDP port."
     categories = ["vxlan"]
     commands = [AntaCommand(command="show interfaces")]
 
@@ -196,7 +196,7 @@ class VerifyVxlan1ConnSettings(AntaTest):
         source_interface: VxlanSrcIntf
         """Source loopback interface of vxlan1 interface"""
         udp_port: int = Field(ge=1024, le=65335)
-        """UDP port used for vxlan interface"""
+        """UDP port used for vxlan1 interface"""
 
     @AntaTest.anta_test
     def test(self) -> None:

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -12,7 +12,9 @@ from ipaddress import IPv4Address
 # Need to keep List and Dict for pydantic in python 3.8
 from typing import Dict, List
 
-from anta.custom_types import Vlan, Vni
+from pydantic import Field
+
+from anta.custom_types import Vlan, Vni, VxlanSrcIntf
 from anta.models import AntaCommand, AntaTest
 from anta.tools.get_value import get_value
 
@@ -171,3 +173,47 @@ class VerifyVxlanVtep(AntaTest):
 
         if difference2:
             self.result.is_failure(f"Unexpected VTEP peer(s) on Vxlan1 interface: {sorted(difference2)}")
+
+
+class VerifyVxlan1ConnSettings(AntaTest):
+    """
+    Verifies the VXLAN source interface and UDP port.
+
+    Expected Results:
+      * success: Passes if VXLAN source interface and UDP port are correct.
+      * failure: Fails if VXLAN source interface or UDP port are incorrect.
+      * skipped: Skips if the Vxlan1 interface is not configured.
+    """
+
+    name = "VerifyVxlan1ConnSettings"
+    description = "Verifies the VXLAN source interface and UDP port"
+    categories = ["vxlan"]
+    commands = [AntaCommand(command="show interfaces")]
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifyVxlan1ConnSettings test."""
+
+        source_interface: VxlanSrcIntf
+        """Source loopback interface of vxlan1 interface"""
+        udp_port: int = Field(ge=1024, le=65335)
+        """UDP port used for vxlan interface"""
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        self.result.is_success()
+        command_output = self.instance_commands[0].json_output
+
+        # Skip the test case if vxlan1 interface is not configured
+        vxlan_output = get_value(command_output, "interfaces.Vxlan1")
+        if not vxlan_output:
+            self.result.is_skipped("Vxlan1 interface is not configured.")
+            return
+
+        src_intf = vxlan_output.get("srcIpIntf")
+        port = vxlan_output.get("udpPort")
+
+        # Check vxlan1 source interface and udp port
+        if src_intf != self.inputs.source_interface:
+            self.result.is_failure(f"Source interface is not correct. Expected `{self.inputs.source_interface}` as source interface but found `{src_intf}` instead.")
+        if port != self.inputs.udp_port:
+            self.result.is_failure(f"UDP port is not correct. Expected `{self.inputs.udp_port}` as UDP port but found `{port}` instead.")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -277,6 +277,9 @@ anta.tests.vxlan:
       vteps:
         - 10.1.1.5
         - 10.1.1.6
+  - VerifyVxlan1ConnSettings:
+      source_interface: Loopback1
+      udp_port: 4789
 
 anta.tests.routing:
   generic:

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -343,7 +343,7 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-wrong-interface",
         "test": VerifyVxlan1ConnSettings,
         "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
-        "inputs": {"source_interface": "Lb1", "udp_port": 4789},
+        "inputs": {"source_interface": "lo1", "udp_port": 4789},
         "expected": {
             "result": "failure",
             "messages": ["Source interface is not correct. Expected `Loopback1` as source interface but found `Loopback10` instead."],

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -343,7 +343,7 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-wrong-interface",
         "test": VerifyVxlan1ConnSettings,
         "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
-        "inputs": {"source_interface": "Loopback1", "udp_port": 4789},
+        "inputs": {"source_interface": "Lb1", "udp_port": 4789},
         "expected": {
             "result": "failure",
             "messages": ["Source interface is not correct. Expected `Loopback1` as source interface but found `Loopback10` instead."],
@@ -353,7 +353,7 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-wrong-port",
         "test": VerifyVxlan1ConnSettings,
         "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
-        "inputs": {"source_interface": "Loopback1", "udp_port": 4780},
+        "inputs": {"source_interface": "Lo1", "udp_port": 4780},
         "expected": {
             "result": "failure",
             "messages": [

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from anta.tests.vxlan import VerifyVxlan1Interface, VerifyVxlanConfigSanity, VerifyVxlanVniBinding, VerifyVxlanVtep
+from anta.tests.vxlan import VerifyVxlan1ConnSettings, VerifyVxlan1Interface, VerifyVxlanConfigSanity, VerifyVxlanVniBinding, VerifyVxlanVtep
 from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
 
 DATA: list[dict[str, Any]] = [
@@ -324,5 +324,42 @@ DATA: list[dict[str, Any]] = [
         "eos_data": [{"vteps": {}, "interfaces": {}}],
         "inputs": {"vteps": ["10.1.1.5", "10.1.1.6", "10.1.1.7"]},
         "expected": {"result": "skipped", "messages": ["Vxlan1 interface is not configured"]},
+    },
+    {
+        "name": "success",
+        "test": VerifyVxlan1ConnSettings,
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback1", "udpPort": 4789}}}],
+        "inputs": {"source_interface": "Loopback1", "udp_port": 4789},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "skipped",
+        "test": VerifyVxlan1ConnSettings,
+        "eos_data": [{"interfaces": {}}],
+        "inputs": {"source_interface": "Loopback1", "udp_port": 4789},
+        "expected": {"result": "skipped", "messages": ["Vxlan1 interface is not configured."]},
+    },
+    {
+        "name": "failure-wrong-interface",
+        "test": VerifyVxlan1ConnSettings,
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
+        "inputs": {"source_interface": "Loopback1", "udp_port": 4789},
+        "expected": {
+            "result": "failure",
+            "messages": ["Source interface is not correct. Expected `Loopback1` as source interface but found `Loopback10` instead."],
+        },
+    },
+    {
+        "name": "failure-wrong-port",
+        "test": VerifyVxlan1ConnSettings,
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
+        "inputs": {"source_interface": "Loopback1", "udp_port": 4780},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Source interface is not correct. Expected `Loopback1` as source interface but found `Loopback10` instead.",
+                "UDP port is not correct. Expected `4780` as UDP port but found `4789` instead.",
+            ],
+        },
     },
 ]


### PR DESCRIPTION
# Description

Added testcase to verify vxlan1 source interface and udp port.

Fixes #553 

Verifies the VXLAN source interface and UDP port.

    Expected Results:
      * success: Passes if VXLAN source interface and UDP port are correct.
      * failure: Fails if VXLAN source interface or UDP port are incorrect.
      * skipped: Skips if the Vxlan1 interface is not configured.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
