### PR TITLE
fix(anta.tests): Fix VerifyInterfacesStatus to support more options for line protocol status

### DIFF
--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -135,6 +135,10 @@ class VerifyInterfacesStatus(AntaTest):
     """
     This test verifies if the provided list of interfaces are all in the expected state.
 
+    - If line protocol status is provided, prioritize checking against both status and line protocol status
+    - If line protocol status is not provided and interface status is "up", expect both status and line protocol to be "up"
+    - If interface status is not "up", check only the interface status without considering line protocol status
+
     Expected Results:
         * success: The test will pass if the provided interfaces are all in the expected state.
         * failure: The test will fail if any interface is not in the expected state.

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -149,7 +149,7 @@ class VerifyInterfacesStatus(AntaTest):
         """Input for the VerifyInterfacesStatus test."""
 
         interfaces: List[InterfaceState]
-        """List of interfaces to validate with the expected state"""
+        """List of interfaces to validate with the expected state."""
 
         class InterfaceState(BaseModel):
             """Model for the interface state input."""
@@ -172,8 +172,8 @@ class VerifyInterfacesStatus(AntaTest):
 
         for interface in self.inputs.interfaces:
             if (intf_status := get_value(command_output["interfaceDescriptions"], interface.name, separator="..")) is None:
-              intf_not_configured.append(interface.name)
-              continue
+                intf_not_configured.append(interface.name)
+                continue
 
             status = "up" if intf_status["interfaceStatus"] in {"up", "connected"} else intf_status["interfaceStatus"]
             proto = "up" if intf_status["lineProtocolStatus"] in {"up", "connected"} else intf_status["lineProtocolStatus"]

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -102,10 +102,12 @@ anta.tests.interfaces:
       interfaces:
         - interface: Ethernet1
           state: up
-        - interface: Ethernet2
-          state: up
-        - interface: Vlan10
+        - interface: Port-Channel100
+          state: down
+          line_protocol_status: lowerLayerDown
+        - interface: Ethernet49/1
           state: adminDown
+          line_protocol_status: notPresent
   - VerifyStormControlDrops:
   - VerifyPortChannels:
   - VerifyIllegalLACP:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -104,10 +104,8 @@ anta.tests.interfaces:
           state: up
         - interface: Ethernet2
           state: up
-          protocol_status: up
         - interface: Vlan10
           state: adminDown
-          protocol_status: down
   - VerifyStormControlDrops:
   - VerifyPortChannels:
   - VerifyIllegalLACP:

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -237,11 +237,13 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
                 }
             }
         ],
-        "inputs": {"interfaces": [
-          {"name": "Ethernet2", "status": "adminDown", "line_protocol_status": "down"},
-          {"name": "Ethernet8", "status": "adminDown", "line_protocol_status": "testing"},
-          {"name": "Ethernet3.10", "status": "down", "line_protocol_status": "dormant"},
-        ]},
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet2", "status": "adminDown", "line_protocol_status": "down"},
+                {"name": "Ethernet8", "status": "adminDown", "line_protocol_status": "testing"},
+                {"name": "Ethernet3.10", "status": "down", "line_protocol_status": "dormant"},
+            ]
+        },
         "expected": {"result": "success"},
     },
     {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -204,14 +204,12 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
             {
                 "interfaceDescriptions": {
                     "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
-                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "up"},
+                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
                     "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                 }
             }
         ],
-        "inputs": {
-            "interfaces": [{"interface": "Ethernet2", "state": "adminDown"}, {"interface": "Ethernet8", "state": "up"}, {"interface": "Ethernet3", "state": "up"}]
-        },
+        "inputs": {"interfaces": [{"name": "Ethernet2", "status": "adminDown"}, {"name": "Ethernet8", "status": "up"}, {"name": "Ethernet3", "status": "up"}]},
         "expected": {"result": "success"},
     },
     {
@@ -221,14 +219,12 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
             {
                 "interfaceDescriptions": {
                     "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
-                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "up"},
+                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
                     "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                 }
             }
         ],
-        "inputs": {
-            "interfaces": [{"interface": "ethernet2", "state": "adminDown"}, {"interface": "ethernet8", "state": "up"}, {"interface": "ethernet3", "state": "up"}]
-        },
+        "inputs": {"interfaces": [{"name": "ethernet2", "status": "adminDown"}, {"name": "ethernet8", "status": "up"}, {"name": "ethernet3", "status": "up"}]},
         "expected": {"result": "success"},
     },
     {
@@ -238,12 +234,12 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
             {
                 "interfaceDescriptions": {
                     "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
-                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "up"},
+                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
                     "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                 }
             }
         ],
-        "inputs": {"interfaces": [{"interface": "eth2", "state": "adminDown"}, {"interface": "et8", "state": "up"}, {"interface": "et3", "state": "up"}]},
+        "inputs": {"interfaces": [{"name": "eth2", "status": "adminDown"}, {"name": "et8", "status": "up"}, {"name": "et3", "status": "up"}]},
         "expected": {"result": "success"},
     },
     {
@@ -256,7 +252,7 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
                 }
             }
         ],
-        "inputs": {"interfaces": [{"interface": "po100", "state": "up"}]},
+        "inputs": {"interfaces": [{"name": "po100", "status": "up"}]},
         "expected": {"result": "success"},
     },
     {
@@ -269,7 +265,33 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
                 }
             }
         ],
-        "inputs": {"interfaces": [{"interface": "Ethernet52/1.1963", "state": "up"}]},
+        "inputs": {"interfaces": [{"name": "Ethernet52/1.1963", "status": "up"}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-transceiver-down",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Ethernet49/1": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "notPresent"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [{"name": "Ethernet49/1", "status": "adminDown"}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-po-down",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Port-Channel100": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "lowerLayerDown"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [{"name": "PortChannel100", "status": "adminDown"}]},
         "expected": {"result": "success"},
     },
     {
@@ -283,37 +305,37 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
                 }
             }
         ],
-        "inputs": {"interfaces": [{"interface": "Ethernet2", "state": "up"}, {"interface": "Ethernet8", "state": "up"}, {"interface": "Ethernet3", "state": "up"}]},
+        "inputs": {"interfaces": [{"name": "Ethernet2", "status": "up"}, {"name": "Ethernet8", "status": "up"}, {"name": "Ethernet3", "status": "up"}]},
         "expected": {
             "result": "failure",
             "messages": ["The following interface(s) are not configured: ['Ethernet8']"],
         },
     },
     {
-        "name": "failure-down",
+        "name": "failure-status-down",
         "test": VerifyInterfacesStatus,
         "eos_data": [
             {
                 "interfaceDescriptions": {
-                    "Ethernet8": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
+                    "Ethernet8": {"interfaceStatus": "down", "description": "", "lineProtocolStatus": "down"},
                     "Ethernet2": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                     "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                 }
             }
         ],
-        "inputs": {"interfaces": [{"interface": "Ethernet2", "state": "up"}, {"interface": "Ethernet8", "state": "up"}, {"interface": "Ethernet3", "state": "up"}]},
+        "inputs": {"interfaces": [{"name": "Ethernet2", "status": "up"}, {"name": "Ethernet8", "status": "up"}, {"name": "Ethernet3", "status": "up"}]},
         "expected": {
             "result": "failure",
-            "messages": ["The following interface(s) are not in the expected state: ['Ethernet8 is down/adminDown expected up/up'"],
+            "messages": ["The following interface(s) are not in the expected state: ['Ethernet8 is down/down'"],
         },
     },
     {
-        "name": "failure-up",
+        "name": "failure-proto-down",
         "test": VerifyInterfacesStatus,
         "eos_data": [
             {
                 "interfaceDescriptions": {
-                    "Ethernet8": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
+                    "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "down"},
                     "Ethernet2": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                     "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
                 }
@@ -321,14 +343,30 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         ],
         "inputs": {
             "interfaces": [
-                {"interface": "Ethernet2", "state": "adminDown", "protocol_status": "down"},
-                {"interface": "Ethernet8", "state": "adminDown"},
-                {"interface": "Ethernet3", "state": "up"},
+                {"name": "Ethernet2", "status": "up"},
+                {"name": "Ethernet8", "status": "up"},
+                {"name": "Ethernet3", "status": "up"},
             ]
         },
         "expected": {
             "result": "failure",
-            "messages": ["The following interface(s) are not in the expected state: ['Ethernet2 is up/up expected down/adminDown'"],
+            "messages": ["The following interface(s) are not in the expected state: ['Ethernet8 is up/down'"],
+        },
+    },
+    {
+        "name": "failure-po-status-down",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Port-Channel100": {"interfaceStatus": "down", "description": "", "lineProtocolStatus": "lowerLayerDown"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [{"name": "PortChannel100", "status": "up"}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["The following interface(s) are not in the expected state: ['Port-Channel100 is down/lowerLayerDown'"],
         },
     },
     {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -213,6 +213,38 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         "expected": {"result": "success"},
     },
     {
+        "name": "success-up-with-line-protocol-status",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "down"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [{"name": "Ethernet8", "status": "up", "line_protocol_status": "down"}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-with-line-protocol-status",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Ethernet8": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "testing"},
+                    "Ethernet2": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "down"},
+                    "Ethernet3.10": {"interfaceStatus": "down", "description": "", "lineProtocolStatus": "dormant"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [
+          {"name": "Ethernet2", "status": "adminDown", "line_protocol_status": "down"},
+          {"name": "Ethernet8", "status": "adminDown", "line_protocol_status": "testing"},
+          {"name": "Ethernet3.10", "status": "down", "line_protocol_status": "dormant"},
+        ]},
+        "expected": {"result": "success"},
+    },
+    {
         "name": "success-lower",
         "test": VerifyInterfacesStatus,
         "eos_data": [
@@ -295,6 +327,19 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         "expected": {"result": "success"},
     },
     {
+        "name": "success-po-lowerlayerdown",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Port-Channel100": {"interfaceStatus": "adminDown", "description": "", "lineProtocolStatus": "lowerLayerDown"},
+                }
+            }
+        ],
+        "inputs": {"interfaces": [{"name": "Port-Channel100", "status": "adminDown", "line_protocol_status": "lowerLayerDown"}]},
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-not-configured",
         "test": VerifyInterfacesStatus,
         "eos_data": [
@@ -367,6 +412,30 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         "expected": {
             "result": "failure",
             "messages": ["The following interface(s) are not in the expected state: ['Port-Channel100 is down/lowerLayerDown'"],
+        },
+    },
+    {
+        "name": "failure-proto-unknown",
+        "test": VerifyInterfacesStatus,
+        "eos_data": [
+            {
+                "interfaceDescriptions": {
+                    "Ethernet8": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "down"},
+                    "Ethernet2": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "unknown"},
+                    "Ethernet3": {"interfaceStatus": "up", "description": "", "lineProtocolStatus": "up"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet2", "status": "up", "line_protocol_status": "down"},
+                {"name": "Ethernet8", "status": "up"},
+                {"name": "Ethernet3", "status": "up"},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": ["The following interface(s) are not in the expected state: ['Ethernet2 is up/unknown'"],
         },
     },
     {


### PR DESCRIPTION
# Description

Fix VerifyInterfacesStatus to support more options for line protocol status.

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
