### PR TITLE
fix(anta.tests): Added testcase to verify IP virtual router mac  address

### DIFF
--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -14,10 +14,12 @@ import re
 from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, conint
+from pydantic_extra_types.mac_address import MacAddress
 
 from anta.custom_types import Interface
 from anta.decorators import skip_on_platforms
 from anta.models import AntaCommand, AntaTemplate, AntaTest
+from anta.tools.get_item import get_item
 from anta.tools.get_value import get_value
 
 
@@ -468,5 +470,35 @@ class VerifyL2MTU(AntaTest):
                     wrong_l2mtu_intf.append({interface: values["mtu"]})
         if wrong_l2mtu_intf:
             self.result.is_failure(f"Some L2 interfaces do not have correct MTU configured:\n{wrong_l2mtu_intf}")
+        else:
+            self.result.is_success()
+
+
+class VerifyIpVirtualRouterMac(AntaTest):
+    """
+    Verifies the IP virtual router MAC address.
+
+    Expected Results:
+        * success: The test will pass if the IP virtual router MAC address matches the input.
+        * failure: The test will fail if the IP virtual router MAC address does not match the input.
+    """
+
+    name = "VerifyIpVirtualRouterMac"
+    description = "Verifies the IP virtual router MAC address."
+    categories = ["interfaces"]
+    commands = [AntaCommand(command="show ip virtual-router")]
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifyIpVirtualRouterMac test."""
+
+        mac_address: MacAddress
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        command_output = self.instance_commands[0].json_output["virtualMacs"]
+        mac_address_found = get_item(command_output, "macAddress", self.inputs.mac_address)
+
+        if mac_address_found is None:
+            self.result.is_failure(f"IP virtual router MAC address `{self.inputs.mac_address}` is not configured.")
         else:
             self.result.is_success()

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -492,6 +492,7 @@ class VerifyIpVirtualRouterMac(AntaTest):
         """Inputs for the VerifyIpVirtualRouterMac test."""
 
         mac_address: MacAddress
+        """IP virtual router MAC address"""
 
     @AntaTest.anta_test
     def test(self) -> None:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -151,6 +151,8 @@ anta.tests.interfaces:
         - Vxlan1
       specific_mtu:
         - Ethernet1/1: 1500
+  - VerifyIpVirtualRouterMac:
+      mac_address: 00:1c:73:00:dc:01
 
 anta.tests.logging:
   - VerifyLoggingPersistent:

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -14,6 +14,7 @@ from anta.tests.interfaces import (
     VerifyInterfacesStatus,
     VerifyInterfaceUtilization,
     VerifyIPProxyARP,
+    VerifyIpVirtualRouterMac,
     VerifyL2MTU,
     VerifyL3MTU,
     VerifyLoopbackCount,
@@ -1059,5 +1060,35 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         ],
         "inputs": {"interfaces": ["Ethernet1", "Ethernet2"]},
         "expected": {"result": "failure", "messages": ["The following interface(s) have Proxy-ARP disabled: ['Ethernet2']"]},
+    },
+    {
+        "name": "success",
+        "test": VerifyIpVirtualRouterMac,
+        "eos_data": [
+            {
+                "virtualMacs": [
+                    {
+                        "macAddress": "00:1c:73:00:dc:01",
+                    }
+                ],
+            }
+        ],
+        "inputs": {"mac_address": "00:1c:73:00:dc:01"},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "faliure-incorrect-mac-address",
+        "test": VerifyIpVirtualRouterMac,
+        "eos_data": [
+            {
+                "virtualMacs": [
+                    {
+                        "macAddress": "00:00:00:00:00:00",
+                    }
+                ],
+            }
+        ],
+        "inputs": {"mac_address": "00:1c:73:00:dc:01"},
+        "expected": {"result": "failure", "messages": ["IP virtual router MAC address `00:1c:73:00:dc:01` is not configured."]},
     },
 ]


### PR DESCRIPTION
# Description

Added testcase to verify IP virtual router mac  address

"""
    Verifies the IP virtual router MAC address.

    Expected Results:
        * success: The test will pass if the IP virtual router MAC address matches the input.
        * failure: The test will fail if the IP virtual router MAC address does not match the input.
"""

Fixes #561 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
