### PR TITLE
fix(anta.tests): Fix an issue in VerifyL2MTU to capture interface name

### DIFF
--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -428,7 +428,7 @@ class VerifyL2MTU(AntaTest):
             for d in self.inputs.specific_mtu:
                 specific_interfaces.extend(d)
         for interface, values in command_output["interfaces"].items():
-            catch_interface = re.findall(r"^(e|p)[a-zA-Z]+[-,a-zA-Z]*\d+\/*\d*", interface, re.IGNORECASE)
+            catch_interface = re.findall(r"^[e,p][a-zA-Z]+[-,a-zA-Z]*\d+\/*\d*", interface, re.IGNORECASE)
             if len(catch_interface) and catch_interface[0] not in self.inputs.ignored_interfaces and values["forwardingModel"] == "bridged":
                 if interface in specific_interfaces:
                     wrong_l2mtu_intf.extend({interface: values["mtu"]} for custom_data in self.inputs.specific_mtu if values["mtu"] != custom_data[interface])

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Arista Networks, Inc.
+# Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """
@@ -428,7 +428,8 @@ class VerifyL2MTU(AntaTest):
             for d in self.inputs.specific_mtu:
                 specific_interfaces.extend(d)
         for interface, values in command_output["interfaces"].items():
-            if re.findall(r"[a-z]+", interface, re.IGNORECASE)[0] not in self.inputs.ignored_interfaces and values["forwardingModel"] == "bridged":
+            catch_interface = re.findall(r"^(e|p)[a-zA-Z]+[-,a-zA-Z]*\d+\/*\d*", interface, re.IGNORECASE)
+            if len(catch_interface) and catch_interface[0] not in self.inputs.ignored_interfaces and values["forwardingModel"] == "bridged":
                 if interface in specific_interfaces:
                     wrong_l2mtu_intf.extend({interface: values["mtu"]} for custom_data in self.inputs.specific_mtu if values["mtu"] != custom_data[interface])
                 # Comparison with generic setting

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Arista Networks, Inc.
+# Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """Test inputs for anta.tests.hardware"""
@@ -810,8 +810,8 @@ Et4                    5:00       0.0  99.9%        0       0.0   0.0%        0
         "eos_data": [
             {
                 "interfaces": {
-                    "Ethernet2": {
-                        "name": "Ethernet2",
+                    "Ethernet2/1": {
+                        "name": "Ethernet2/1",
                         "forwardingModel": "routed",
                         "lineProtocolStatus": "up",
                         "interfaceStatus": "connected",


### PR DESCRIPTION
# Description

Fix an issue where interface name like `Ethernet1/1` or `Port-Channel1` were not caught by the test reporting `VerifyL2MTU`

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
