### PR TITLE
feat(anta.tests): Added testcase to verify router path-selection paths

### DIFF
--- a/anta/tests/path_selection.py
+++ b/anta/tests/path_selection.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""
+Test functions related to various router path-selection settings
+"""
+# Mypy does not understand AntaTest.Input typing
+# mypy: disable-error-code=attr-defined
+from __future__ import annotations
+
+from ipaddress import IPv4Address
+
+# Need to keep List for pydantic in python 3.8
+from typing import List
+
+from pydantic import BaseModel
+
+from anta.models import AntaCommand, AntaTemplate, AntaTest
+from anta.tools.get_value import get_value
+
+
+class VerifyRouterPathsHealth(AntaTest):
+    """
+    Verifies the state of all paths under router path-selection as ipsecEstablished.
+
+    Expected Results:
+        * success: The test will pass if all the paths under router path-selection are ipsecEstablished.
+        * failure: The test will fail if router path-selection is not configured or any path's state is not ipsecEstablished.
+    """
+
+    name = "VerifyRouterPathsHealth"
+    description = "Verifies the state of all paths under router path-selection as ipsecEstablished."
+    categories = ["path-selection"]
+    commands = [AntaCommand(command="show path-selection paths")]
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        self.result.is_success()
+
+        command_output = self.instance_commands[0].json_output["dpsPeers"]
+
+        # If no paths are configured for router path-selection, the test fails
+        if not command_output:
+            self.result.is_failure("No paths are configured for router path-selection.")
+            return
+
+        # Check the state of each path
+        failed_log = ""
+        for peer, peer_data in command_output.items():
+            for group, group_data in peer_data["dpsGroups"].items():
+                for _, path_data in group_data["dpsPaths"].items():
+                    state = path_data["state"]
+
+                    # If the state of any path is not 'ipsecEstablished', the test fails
+                    if state != "ipsecEstablished":
+                        failed_log += f"\nPeer {peer} in group {group} is `{state}`."
+        if failed_log:
+            self.result.is_failure(f"State of following peers is not `ipsecEstablished`:{failed_log}")
+
+
+class VerifySpecificRouterPath(AntaTest):
+    """
+    Verifies the state of a specific path under router path-selection as ipsecEstablished.
+
+    Expected Results:
+        * success: The test will pass if the input path under router path-selection is ipsecEstablished.
+        * failure: The test will fail if the input path is not found or its state is not ipsecEstablished.
+    """
+
+    name = "VerifySpecificRouterPath"
+    description = "Verifies the state of a specific path under router path-selection as ipsecEstablished."
+    categories = ["path-selection"]
+    commands = [AntaTemplate(template="show path-selection paths peer {peer} path-group {group}")]
+
+    class Input(AntaTest.Input):
+        """Inputs for the VerifySpecificRouterPath test."""
+
+        paths: List[RouterPath]
+        """List of router paths to verify"""
+
+        class RouterPath(BaseModel):
+            """Detail of a router path"""
+
+            peer: IPv4Address
+            """Static peer IPv4 address"""
+
+            path_groups: list[str]
+            """Router path group names"""
+
+    def render(self, template: AntaTemplate) -> list[AntaCommand]:
+        return [template.render(peer=path.peer, group=path_group) for path in self.inputs.paths for path_group in path.path_groups]
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        self.result.is_success()
+
+        # Check the state of each path
+        for command in self.instance_commands:
+            peer = str(command.params["peer"])
+            path_group = command.params["group"]
+            command_output = command.json_output["dpsPeers"]
+
+            # If the peer is not configured for the path group, the test fails
+            if not command_output:
+                self.result.is_failure(f"Peer `{peer}` is not configured for path group `{path_group}`.")
+                continue
+
+            # Extract the state of the path
+            path_output = get_value(command_output, f"{peer}..dpsGroups..{path_group}..dpsPaths", separator="..")
+            state = list(path_output.values())[0].get("state")
+
+            # If the state of the path is not 'ipsecEstablished', the test fails
+            if state != "ipsecEstablished":
+                self.result.is_failure(f"Peer {peer} in group {path_group} is `{state}`.")

--- a/docs/api/tests.md
+++ b/docs/api/tests.md
@@ -19,6 +19,7 @@ This section describes all the available tests provided by ANTA package.
 - [Logging](tests.logging.md)
 - [MLAG](tests.mlag.md)
 - [Multicast](tests.multicast.md)
+- [Router Path Selection](tests.path_selection.md)
 - [Profiles](tests.profiles.md)
 - [Routing Generic](tests.routing.generic.md)
 - [Routing BGP](tests.routing.bgp.md)

--- a/docs/api/tests.path_selection.md
+++ b/docs/api/tests.path_selection.md
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+# ANTA catalog for Router path-selection tests
+
+::: anta.tests.path_selection
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      merge_init_into_class: false

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -202,6 +202,15 @@ anta.tests.multicast:
   - VerifyIGMPSnoopingGlobal:
       enabled: True
 
+anta.tests.path_selection:
+  - VerifyRouterPathsHealth:
+  - VerifySpecificRouterPath:
+      paths:
+        - peer: 10.255.0.1
+          path_groups:
+            - internet
+            - mpls
+
 anta.tests.profiles:
   - VerifyUnifiedForwardingTableMode:
       mode: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
     - Logging: api/tests.logging.md
     - MLAG: api/tests.mlag.md
     - Multicast: api/tests.multicast.md
+    - Router Path Selection: api/tests.path_selection.md
     - Profiles: api/tests.profiles.md
     - Routing:
       - Generic: api/tests.routing.generic.md

--- a/tests/units/anta_tests/test_path_selection.py
+++ b/tests/units/anta_tests/test_path_selection.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""
+Tests for anta.tests.path_selection.py
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from anta.tests.path_selection import VerifyRouterPathsHealth, VerifySpecificRouterPath
+from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
+
+DATA: list[dict[str, Any]] = [
+    {
+        "name": "success",
+        "test": VerifyRouterPathsHealth,
+        "eos_data": [
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path3": {
+                                        "state": "ipsecEstablished",
+                                    },
+                                },
+                            },
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path4": {
+                                        "state": "ipsecEstablished",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path1": {
+                                        "state": "ipsecEstablished",
+                                    },
+                                },
+                            },
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path2": {
+                                        "state": "ipsecEstablished",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+        ],
+        "inputs": {},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-no-peer",
+        "test": VerifyRouterPathsHealth,
+        "eos_data": [
+            {"dpsPeers": {}},
+        ],
+        "inputs": {},
+        "expected": {"result": "failure", "messages": ["No paths are configured for router path-selection."]},
+    },
+    {
+        "name": "failure-not-established",
+        "test": VerifyRouterPathsHealth,
+        "eos_data": [
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path3": {
+                                        "state": "ipsecPending",
+                                    },
+                                },
+                            },
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path4": {
+                                        "state": "ipsecPending",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path1": {
+                                        "state": "ipsecEstablished",
+                                    },
+                                },
+                            },
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path2": {
+                                        "state": "ipsecPending",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }
+            },
+        ],
+        "inputs": {},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "State of following peers is not `ipsecEstablished`:\n"
+                "Peer 10.255.0.1 in group internet is `ipsecPending`.\n"
+                "Peer 10.255.0.1 in group mpls is `ipsecPending`.\n"
+                "Peer 10.255.0.2 in group mpls is `ipsecPending`."
+            ],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifySpecificRouterPath,
+        "eos_data": [
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path3": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path4": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path2": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path1": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        ],
+        "inputs": {"paths": [{"peer": "10.255.0.1", "path_groups": ["internet", "mpls"]}, {"peer": "10.255.0.2", "path_groups": ["internet", "mpls"]}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-no-peer",
+        "test": VerifySpecificRouterPath,
+        "eos_data": [
+            {"dpsPeers": {}},
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path4": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path2": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {"dpsPeers": {}},
+        ],
+        "inputs": {"paths": [{"peer": "10.255.0.1", "path_groups": ["internet", "mpls"]}, {"peer": "10.255.0.2", "path_groups": ["internet", "mpls"]}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["Peer `10.255.0.1` is not configured for path group `internet`.", "Peer `10.255.0.2` is not configured for path group `mpls`."],
+        },
+    },
+    {
+        "name": "failure-not-established",
+        "test": VerifySpecificRouterPath,
+        "eos_data": [
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path3": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.1": {
+                        "dpsGroups": {
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path4": {
+                                        "state": "ipsecPending",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "internet": {
+                                "dpsPaths": {
+                                    "path2": {
+                                        "state": "ipsecEstablished",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "dpsPeers": {
+                    "10.255.0.2": {
+                        "dpsGroups": {
+                            "mpls": {
+                                "dpsPaths": {
+                                    "path1": {
+                                        "state": "ipsecPending",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        ],
+        "inputs": {"paths": [{"peer": "10.255.0.1", "path_groups": ["internet", "mpls"]}, {"peer": "10.255.0.2", "path_groups": ["internet", "mpls"]}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["Peer 10.255.0.1 in group mpls is `ipsecPending`.", "Peer 10.255.0.2 in group mpls is `ipsecPending`."],
+        },
+    },
+]


### PR DESCRIPTION
# Description

Added testcase to verify router path-selection paths.

**VerifyRouterPathsHealth**
"""
    Verifies the state of all paths under router path-selection as ipsecEstablished.

    Expected Results:
        * success: The test will pass if all the paths under router path-selection are ipsecEstablished.
        * failure: The test will fail if router path-selection is not configured or any path's state is not ipsecEstablished.
"""

**VerifySpecificRouterPath**
"""
    Verifies the state of a specific path under router path-selection as ipsecEstablished.

    Expected Results:
        * success: The test will pass if the input path under router path-selection is ipsecEstablished.
        * failure: The test will fail if the input path is not found or its state is not ipsecEstablished.
"""

Fixes #577 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
