### PR TITLE
fix(anta.tests): Fix VerifyLLDPNeighbors to support multiple LLDP neighbors on the same port

### DIFF
--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -107,22 +107,38 @@ class VerifyLLDPNeighbors(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyLLDPNeighbors."""
-        command_output = self.instance_commands[0].json_output
-
+        failure_type_map = {
+            "port_not_configured": "Port(s) not configured",
+            "no_lldp_neighbor": "No LLDP neighbor(s)",
+            "wrong_lldp_neighbor": "Wrong LLDP neighbor(s)",
+        }
         failures: dict[str, list[str]] = {}
 
+        command_output = self.instance_commands[0].json_output
+
         for neighbor in self.inputs.neighbors:
+            neighbor_found = False
             if neighbor.port not in command_output["lldpNeighbors"]:
                 failures.setdefault("port_not_configured", []).append(neighbor.port)
-            elif len(lldp_neighbor_info := command_output["lldpNeighbors"][neighbor.port]["lldpNeighborInfo"]) == 0:
+                continue
+
+            if len(lldp_neighbor_info := command_output["lldpNeighbors"][neighbor.port]["lldpNeighborInfo"]) == 0:
                 failures.setdefault("no_lldp_neighbor", []).append(neighbor.port)
-            elif (
-                lldp_neighbor_info[0]["systemName"] != neighbor.neighbor_device
-                or lldp_neighbor_info[0]["neighborInterfaceInfo"]["interfaceId_v2"] != neighbor.neighbor_port
-            ):
+                continue
+
+            for info in lldp_neighbor_info:
+                if info["systemName"] == neighbor.neighbor_device and info["neighborInterfaceInfo"]["interfaceId_v2"] == neighbor.neighbor_port:
+                    neighbor_found = True
+                    break
+
+            if neighbor_found is False:
                 failures.setdefault("wrong_lldp_neighbor", []).append(neighbor.port)
 
         if not failures:
             self.result.is_success()
         else:
-            self.result.is_failure(f"The following port(s) have issues: {failures}")
+            failure_messages = []
+            for failure_type, ports in failures.items():
+                ports_str = ", ".join(ports)
+                failure_messages.append(f"{failure_type_map[failure_type]}: {ports_str}")
+            self.result.is_failure("\n".join(failure_messages))

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -215,6 +215,48 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-multiple-neighbors",
+        "test": VerifyLLDPNeighbors,
+        "inputs": {
+            "neighbors": [
+                {"port": "Ethernet1", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
+            ],
+        },
+        "eos_data": [
+            {
+                "lldpNeighbors": {
+                    "Ethernet1": {
+                        "lldpNeighborInfo": [
+                            {
+                                "chassisIdType": "macAddress",
+                                "chassisId": "001c.73a0.fc18",
+                                "systemName": "DC1-SPINE1",
+                                "neighborInterfaceInfo": {
+                                    "interfaceIdType": "interfaceName",
+                                    "interfaceId": '"Ethernet1"',
+                                    "interfaceId_v2": "Ethernet1",
+                                    "interfaceDescription": "P2P_LINK_TO_DC1-LEAF1A_Ethernet1",
+                                },
+                            },
+                            {
+                                "chassisIdType": "macAddress",
+                                "chassisId": "001c.73f7.d138",
+                                "systemName": "DC1-SPINE2",
+                                "neighborInterfaceInfo": {
+                                    "interfaceIdType": "interfaceName",
+                                    "interfaceId": '"Ethernet1"',
+                                    "interfaceId_v2": "Ethernet1",
+                                    "interfaceDescription": "P2P_LINK_TO_DC1-LEAF1A_Ethernet2",
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-port-not-configured",
         "test": VerifyLLDPNeighbors,
         "inputs": {
@@ -244,7 +286,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'port_not_configured': ['Ethernet2']}"]},
+        "expected": {"result": "failure", "messages": ["Port(s) not configured: Ethernet2"]},
     },
     {
         "name": "failure-no-neighbor",
@@ -277,7 +319,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'no_lldp_neighbor': ['Ethernet2']}"]},
+        "expected": {"result": "failure", "messages": ["No LLDP neighbor(s): Ethernet2"]},
     },
     {
         "name": "failure-wrong-neighbor",
@@ -324,7 +366,7 @@ DATA: list[dict[str, Any]] = [
                 },
             },
         ],
-        "expected": {"result": "failure", "messages": ["The following port(s) have issues: {'wrong_lldp_neighbor': ['Ethernet2']}"]},
+        "expected": {"result": "failure", "messages": ["Wrong LLDP neighbor(s): Ethernet2"]},
     },
     {
         "name": "failure-multiple",
@@ -360,9 +402,49 @@ DATA: list[dict[str, Any]] = [
         ],
         "expected": {
             "result": "failure",
-            "messages": [
-                "The following port(s) have issues: {'wrong_lldp_neighbor': ['Ethernet1'], 'no_lldp_neighbor': ['Ethernet2'], 'port_not_configured': ['Ethernet3']}",
+            "messages": ["Wrong LLDP neighbor(s): Ethernet1\nNo LLDP neighbor(s): Ethernet2\nPort(s) not configured: Ethernet3"],
+        },
+    },
+    {
+        "name": "failure-multiple-neighbors",
+        "test": VerifyLLDPNeighbors,
+        "inputs": {
+            "neighbors": [
+                {"port": "Ethernet1", "neighbor_device": "DC1-SPINE3", "neighbor_port": "Ethernet1"},
             ],
         },
+        "eos_data": [
+            {
+                "lldpNeighbors": {
+                    "Ethernet1": {
+                        "lldpNeighborInfo": [
+                            {
+                                "chassisIdType": "macAddress",
+                                "chassisId": "001c.73a0.fc18",
+                                "systemName": "DC1-SPINE1",
+                                "neighborInterfaceInfo": {
+                                    "interfaceIdType": "interfaceName",
+                                    "interfaceId": '"Ethernet1"',
+                                    "interfaceId_v2": "Ethernet1",
+                                    "interfaceDescription": "P2P_LINK_TO_DC1-LEAF1A_Ethernet1",
+                                },
+                            },
+                            {
+                                "chassisIdType": "macAddress",
+                                "chassisId": "001c.73f7.d138",
+                                "systemName": "DC1-SPINE2",
+                                "neighborInterfaceInfo": {
+                                    "interfaceIdType": "interfaceName",
+                                    "interfaceId": '"Ethernet1"',
+                                    "interfaceId_v2": "Ethernet1",
+                                    "interfaceDescription": "P2P_LINK_TO_DC1-LEAF1A_Ethernet2",
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+        "expected": {"result": "failure", "messages": ["Wrong LLDP neighbor(s): Ethernet1"]},
     },
 ]


### PR DESCRIPTION
# Description

Fix `VerifyLLDPNeighbors` test to support multiple neighbors on the same port.

Update failure message to a more human readable format to make AVD report happy.

Fixes https://github.com/aristanetworks/avd/issues/3737

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
