### PR TITLE
fix(anta.tests): Added 'cEOSCloudLab' in skip decorator

### DIFF
--- a/anta/tests/field_notices.py
+++ b/anta/tests/field_notices.py
@@ -39,7 +39,7 @@ class VerifyFieldNotice44Resolution(AntaTest):
     categories: ClassVar[list[str]] = ["field notices"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version detail")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyFieldNotice44Resolution."""
@@ -143,7 +143,7 @@ class VerifyFieldNotice72Resolution(AntaTest):
     categories: ClassVar[list[str]] = ["field notices"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version detail")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyFieldNotice72Resolution."""

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -47,7 +47,7 @@ class VerifyTransceiversManufacturers(AntaTest):
         manufacturers: list[str]
         """List of approved transceivers manufacturers."""
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyTransceiversManufacturers."""
@@ -82,7 +82,7 @@ class VerifyTemperature(AntaTest):
     categories: ClassVar[list[str]] = ["hardware"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show system environment temperature", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyTemperature."""
@@ -115,7 +115,7 @@ class VerifyTransceiversTemperature(AntaTest):
     categories: ClassVar[list[str]] = ["hardware"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show system environment temperature transceiver", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyTransceiversTemperature."""
@@ -156,7 +156,7 @@ class VerifyEnvironmentSystemCooling(AntaTest):
     categories: ClassVar[list[str]] = ["hardware"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show system environment cooling", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyEnvironmentSystemCooling."""
@@ -196,7 +196,7 @@ class VerifyEnvironmentCooling(AntaTest):
         states: list[str]
         """List of accepted states of fan status."""
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyEnvironmentCooling."""
@@ -243,7 +243,7 @@ class VerifyEnvironmentPower(AntaTest):
         states: list[str]
         """List of accepted states list of power supplies status."""
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyEnvironmentPower."""
@@ -279,7 +279,7 @@ class VerifyAdverseDrops(AntaTest):
     categories: ClassVar[list[str]] = ["hardware"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show hardware counter drop", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyAdverseDrops."""

--- a/anta/tests/lanz.py
+++ b/anta/tests/lanz.py
@@ -35,7 +35,7 @@ class VerifyLANZ(AntaTest):
     categories: ClassVar[list[str]] = ["lanz"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show queue-monitor length status")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyLANZ."""

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -44,7 +44,7 @@ class VerifyUnifiedForwardingTableMode(AntaTest):
         mode: Literal[0, 1, 2, 3, 4, "flexible"]
         """Expected UFT mode. Valid values are 0, 1, 2, 3, 4, or "flexible"."""
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyUnifiedForwardingTableMode."""
@@ -83,7 +83,7 @@ class VerifyTcamProfile(AntaTest):
         profile: str
         """Expected TCAM profile."""
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyTcamProfile."""

--- a/anta/tests/ptp.py
+++ b/anta/tests/ptp.py
@@ -38,7 +38,7 @@ class VerifyPtpModeStatus(AntaTest):
     categories: ClassVar[list[str]] = ["ptp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ptp", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPtpModeStatus."""
@@ -85,7 +85,7 @@ class VerifyPtpGMStatus(AntaTest):
     categories: ClassVar[list[str]] = ["ptp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ptp", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPtpGMStatus."""
@@ -125,7 +125,7 @@ class VerifyPtpLockStatus(AntaTest):
     categories: ClassVar[list[str]] = ["ptp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ptp", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPtpLockStatus."""
@@ -166,7 +166,7 @@ class VerifyPtpOffset(AntaTest):
     categories: ClassVar[list[str]] = ["ptp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ptp monitor", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPtpOffset."""
@@ -211,7 +211,7 @@ class VerifyPtpPortModeStatus(AntaTest):
     categories: ClassVar[list[str]] = ["ptp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ptp", ofmt="json")]
 
-    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPtpPortModeStatus."""


### PR DESCRIPTION
# Description

Added 'cEOSCloudLab' in skip decorator.

Fixes #560 

1. VerifyFieldNotice44Resolution: Command(`show version detail`) is supported but its verify Aboot version per FN0044 which is not needed for cEOSCloudLab.
2. VerifyFieldNotice72Resolution: Command(`show version detail`) is supported but its verify the device is exposed to FN0072, and if the issue has been mitigated which is not needed for cEOSCloudLab.
3. VerifyTransceiversManufacturers: No xcvrSlots for cEOSCloudLab device.
4. VerifyTemperature: No need to check temp for cEOSCloudLab device.
5. VerifyTransceiversTemperature: No need to check temp for cEOSCloudLab device.
6. VerifyEnvironmentSystemCooling: No need to check cooling for cEOSCloudLab device.
7. VerifyEnvironmentCooling: No need to check cooling of power and fan slots for cEOSCloudLab device.
8. VerifyEnvironmentPower: No Need to check power state for cEOSCloudLab device.
9. VerifyAdverseDrops: No need to check adverse drops for cEOSCloudLab device.
10. VerifyStormControlDrops: @carl-baillargeon need your input here. Not made any change right now.
11. VerifyPortChannels: @carl-baillargeon i think we dont need to skip this test for VM devices as command supports and gives proper output.
12. VerifyLANZ: Command not support
13. VerifyUnifiedForwardingTableMode: @carl-baillargeon  I think command is depricated as current command is invalid(show platform trident forwarding-table partition)
14. VerifyTcamProfile: @carl-baillargeon need your input here.
15. VerifyPtpModeStatus: command not supported
16. VerifyPtpGMStatus: command not supported.
17. VerifyPtpLockStatus: command not supported.
18. VerifyPtpOffset: command not supported.
19. VerifyPtpPortModeStatus: command not supported.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
