### PR TITLE
ci: Update pre-commit mypy additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,18 +79,9 @@ repos:
         args:
           - --config-file=pyproject.toml
         additional_dependencies:
-          - "aio-eapi==0.3.0"
-          - "click==8.1.3"
-          - "click-help-colors==0.9.1"
-          - "cvprac~=1.3"
-          - "netaddr==0.8.0"
-          - "pydantic~=2.0"
-          - "PyYAML==6.0"
-          - "requests>=2.27"
-          - "rich~=13.4"
-          - "asyncssh==2.13.1"
-          - "Jinja2==3.1.2"
+          - anta[cli]
           - types-PyYAML
-          - types-paramiko
           - types-requests
+          - types-pyOpenSSL
+          - pytest
         files: ^(anta|tests)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,14 @@ license = { file = "LICENSE" }
 dependencies = [
   "aiocache>=0.12.2",
   "aio-eapi>=0.6.3",
+  "asyncssh>=2.13.2",
   "cvprac>=1.3.1",
+  "eval-type-backport>=0.1.3",  # Support newer typing features in older Python versions (required until Python 3.9 support is removed)
+  "Jinja2>=3.1.2",
   "pydantic>=2.6.1",
   "pydantic-extra-types>=2.3.0",
-  "eval-type-backport>=0.1.3",  # Support newer typing features in older Python versions (required until Python 3.9 support is removed)
   "PyYAML>=6.0",
   "requests>=2.31.0",
-  "asyncssh>=2.13.2",
-  "Jinja2>=3.1.2",
   "rich>=13.5.2,<14",
 ]
 keywords = ["test", "anta", "Arista", "network", "automation", "networking", "devops", "netdevops"]
@@ -58,37 +58,37 @@ cli = [
 dev = [
   "bumpver>=2023.1129",
   "codespell~=2.2.6",
-  "mypy~=1.9",
   "mypy-extensions~=1.0",
+  "mypy~=1.9",
   "pre-commit>=3.3.3",
+  "pylint-pydantic>=0.2.4",
   "pylint>=2.17.5",
-  "ruff>=0.3.7,<0.5.0",
-  "pytest>=7.4.0",
   "pytest-asyncio>=0.21.1",
   "pytest-cov>=4.1.0",
   "pytest-dependency",
   "pytest-html>=3.2.0",
   "pytest-metadata>=3.0.0",
-  "pylint-pydantic>=0.2.4",
+  "pytest>=7.4.0",
+  "ruff>=0.3.7,<0.5.0",
   "tox>=4.10.0,<5.0.0",
   "types-PyYAML",
-  "types-paramiko",
+  "types-pyOpenSSL",
   "types-requests",
   "typing-extensions",
   "yamllint>=1.32.0",
 ]
 doc = [
   "fontawesome_markdown",
-  "mkdocs>=1.3.1",
+  "griffe",
+  "mike==2.0.0",
   "mkdocs-autorefs>=0.4.1",
   "mkdocs-bootswatch>=1.1",
   "mkdocs-git-revision-date-localized-plugin>=1.1.0",
   "mkdocs-git-revision-date-plugin>=0.3.2",
-  "mkdocs-material>=8.3.9",
   "mkdocs-material-extensions>=1.0.3",
+  "mkdocs-material>=8.3.9",
+  "mkdocs>=1.3.1",
   "mkdocstrings[python]>=0.20.0",
-  "mike==2.0.0",
-  "griffe",
 ]
 
 [project.urls]
@@ -133,6 +133,8 @@ plugins = [
   ]
 # Comment below for better type checking
 #follow_imports = "skip"
+# Make it false if we implement stubs using stubgen from mypy for aio-eapi, aiocache and cvprac
+# and configure mypy_path to generated stubs e.g.: mypy_path = "./out"
 ignore_missing_imports = true
 warn_redundant_casts = true
 # Note: tox find some unused type ignore which are required for pre-commit


### PR DESCRIPTION
# Description

* sort dep in pyproject

# Fixes

Current pre-commit hook was failing with Python3.12 because of Pyyaml 6.0.0 hardcoded (https://github.com/yaml/pyyaml/issues/756)

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
