### PR TITLE
doc(anta): Update CSS for better titles readability

### DIFF
--- a/docs/stylesheets/extra.material.css
+++ b/docs/stylesheets/extra.material.css
@@ -2,11 +2,15 @@
   --md-hue: 210;
 }
 
+#page {
+  counter-reset: heading;
+}
+
 :root {
   /* Color schema based on Arista Color Schema */
   /* Default color shades */
   --md-default-fg-color:               #000000;
-  --md-default-fg-color--light:        #a1a0a0;
+  --md-default-fg-color--light:        #444343;
   --md-default-fg-color--lighter:      #FFFFFF;
   --md-default-fg-color--lightest:     #FFFFFF;
   --md-default-bg-color:               #FFFFFF;
@@ -49,6 +53,9 @@
 
 [data-md-color-scheme="slate"] {
 
+  /* Default color shades */
+  --md-default-fg-color--light: #949393;
+
   /* Link color */
   --md-typeset-a-color:                #75aaf8;
   --md-typeset-a-color-fg:             #FFFFFF;
@@ -76,6 +83,7 @@
 }
 
 @media only screen {
+
   .md-typeset a:hover {
     background-color: var(--md-typeset-a-color-bg);
     color: var(--md-typeset-a-color-fg);
@@ -102,13 +110,47 @@
     color: var(--md-default-fg-color--light);
   }
 
-  .md-typeset h4 h5 h6 {
-      font-size: 1.5rem;
+  /* .md-typeset h3:before {
+    content: counter(heading)". ";
+    counter-increment: heading;
+  }
+
+  .md-typeset h4:before {
+    content: counter(heading + 1)"." counter(subheading)". ";
+    counter-increment: subheading;
+  } */
+
+  .md-typeset h3 {
+    font-size: 1.5rem;
+    margin: 1em 0;
+    /* font-weight: 700; */
+    letter-spacing: -.01em;
+    line-height: 3em;
+    color: var(--md-default-fg-color--light);
+    text-transform: uppercase;
+  }
+
+  .md-typeset h4 {
+    font-size: 1.5rem;
+    margin: 1em 0;
+    /* font-weight: 700; */
+    letter-spacing: -.01em;
+    line-height: 2em;
+    color: var(--md-default-fg-color--light);
+    text-transform: uppercase;
+  }
+
+    .md-typeset h5,
+    .md-typeset h6 {
+      font-size: 0.9rem;
       margin: 1em 0;
       /* font-weight: 700; */
       letter-spacing: -.01em;
-      line-height: 3em;
-  }
+      /* line-height: 2em; */
+      color: var(--md-default-fg-color--light);
+      font-style: italic;
+      text-transform: capitalize;
+    }
 
   .md-typeset table:not([class]) th {
     min-width: 5rem;

--- a/docs/stylesheets/extra.material.css
+++ b/docs/stylesheets/extra.material.css
@@ -110,47 +110,57 @@
     color: var(--md-default-fg-color--light);
   }
 
-  /* .md-typeset h3:before {
-    content: counter(heading)". ";
-    counter-increment: heading;
-  }
-
-  .md-typeset h4:before {
-    content: counter(heading + 1)"." counter(subheading)". ";
-    counter-increment: subheading;
-  } */
-
-  .md-typeset h3 {
+  .md-typeset h2 {
+    line-height: 2em;
     font-size: 1.5rem;
     margin: 1em 0;
     /* font-weight: 700; */
     letter-spacing: -.01em;
-    line-height: 3em;
     color: var(--md-default-fg-color--light);
     text-transform: uppercase;
+    font-style: normal;
+    font-weight: bolder;
+  }
+
+  .md-typeset h3 {
+    line-height: 1em;
+    font-size: 1.3rem;
+    margin: 1em 0;
+    /* font-weight: 700; */
+    letter-spacing: -.01em;
+    color: var(--md-default-fg-color--light);
+    text-transform: uppercase;
+    font-style: normal;
+    font-weight: bold;
+  }
+
+  .md-typeset h4::before {
+    content: ">> ";
   }
 
   .md-typeset h4 {
-    font-size: 1.5rem;
+    font-size: 1.1rem;
+    margin: 1em 0;
+    font-weight: 700;
+    letter-spacing: -.01em;
+    line-height: 1em;
+    color: var(--md-default-fg-color--light);
+    font-style: italic;
+    text-transform: capitalize;
+  }
+
+  .md-typeset h5,
+  .md-typeset h6 {
+    font-size: 0.9rem;
     margin: 1em 0;
     /* font-weight: 700; */
     letter-spacing: -.01em;
-    line-height: 2em;
+    /* line-height: 2em; */
     color: var(--md-default-fg-color--light);
-    text-transform: uppercase;
+    font-style: italic;
+    text-transform: capitalize;
+    text-decoration: underline;
   }
-
-    .md-typeset h5,
-    .md-typeset h6 {
-      font-size: 0.9rem;
-      margin: 1em 0;
-      /* font-weight: 700; */
-      letter-spacing: -.01em;
-      /* line-height: 2em; */
-      color: var(--md-default-fg-color--light);
-      font-style: italic;
-      text-transform: capitalize;
-    }
 
   .md-typeset table:not([class]) th {
     min-width: 5rem;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,7 @@ markdown_extensions:
       separator: "-"
       # permalink: "#"
       permalink: true
-      baselevel: 3
+      # baselevel: 3
   - pymdownx.highlight
   - pymdownx.snippets:
       base_path:


### PR DESCRIPTION
# Description

Update CSS to make H3,H4,H5 and H6 title bit more readable with more emphasis

To test:

```bash
mkdocs serve
```

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
