### PR TITLE
Optimize VerifyRoutingTableEntry by quering all routes for a vrf.

### DIFF
--- a/tests/units/anta_tests/routing/test_generic.py
+++ b/tests/units/anta_tests/routing/test_generic.py
@@ -99,18 +99,6 @@ DATA: list[dict[str, Any]] = [
                                 "metric": 0,
                                 "vias": [{"nexthopAddr": "10.1.255.4", "interface": "Ethernet1"}],
                             },
-                        },
-                    },
-                },
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "routingDisabled": False,
-                        "allRoutesProgrammedHardware": True,
-                        "allRoutesProgrammedKernel": True,
-                        "defaultRouteState": "notSet",
-                        "routes": {
                             "10.1.0.2/32": {
                                 "hardwareProgrammed": True,
                                 "routeType": "eBGP",
@@ -134,17 +122,6 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-missing-route",
         "test": VerifyRoutingTableEntry,
         "eos_data": [
-            {
-                "vrfs": {
-                    "default": {
-                        "routingDisabled": False,
-                        "allRoutesProgrammedHardware": True,
-                        "allRoutesProgrammedKernel": True,
-                        "defaultRouteState": "notSet",
-                        "routes": {},
-                    },
-                },
-            },
             {
                 "vrfs": {
                     "default": {
@@ -195,18 +172,6 @@ DATA: list[dict[str, Any]] = [
                                 "metric": 0,
                                 "vias": [{"nexthopAddr": "10.1.255.4", "interface": "Ethernet1"}],
                             },
-                        },
-                    },
-                },
-            },
-            {
-                "vrfs": {
-                    "default": {
-                        "routingDisabled": False,
-                        "allRoutesProgrammedHardware": True,
-                        "allRoutesProgrammedKernel": True,
-                        "defaultRouteState": "notSet",
-                        "routes": {
                             "10.1.0.55/32": {
                                 "hardwareProgrammed": True,
                                 "routeType": "eBGP",


### PR DESCRIPTION
# Description

Reduce number of commands executed on VerifyRoutingTableEntry by querying all routes of a vrf in one go.


# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
