### PR TITLE
fix(anta.tests): Fix PTP tests to be skipped be PTP is not configured

### DIFF
--- a/anta/tests/ptp.py
+++ b/anta/tests/ptp.py
@@ -23,7 +23,7 @@ class VerifyPtpModeStatus(AntaTest):
     ----------------
     * Success: The test will pass if the device is a BC.
     * Failure: The test will fail if the device is not a BC.
-    * Error: The test will error if the 'ptpMode' variable is not present in the command output.
+    * Skipped: The test will be skipped if PTP is not configured on the device.
 
     Examples
     --------
@@ -45,7 +45,7 @@ class VerifyPtpModeStatus(AntaTest):
         command_output = self.instance_commands[0].json_output
 
         if (ptp_mode := command_output.get("ptpMode")) is None:
-            self.result.is_error("'ptpMode' variable is not present in the command output")
+            self.result.is_skipped("PTP is not configured")
             return
 
         if ptp_mode != "ptpBoundaryClock":
@@ -63,7 +63,7 @@ class VerifyPtpGMStatus(AntaTest):
     ----------------
     * Success: The test will pass if the device is locked to the provided Grandmaster.
     * Failure: The test will fail if the device is not locked to the provided Grandmaster.
-    * Error: The test will error if the 'gmClockIdentity' variable is not present in the command output.
+    * Skipped: The test will be skipped if PTP is not configured on the device.
 
     Examples
     --------
@@ -92,7 +92,7 @@ class VerifyPtpGMStatus(AntaTest):
         command_output = self.instance_commands[0].json_output
 
         if (ptp_clock_summary := command_output.get("ptpClockSummary")) is None:
-            self.result.is_error("'ptpClockSummary' variable is not present in the command output")
+            self.result.is_skipped("PTP is not configured")
             return
 
         if ptp_clock_summary["gmClockIdentity"] != self.inputs.gmid:
@@ -110,7 +110,7 @@ class VerifyPtpLockStatus(AntaTest):
     ----------------
     * Success: The test will pass if the device was locked to the upstream GM in the last minute.
     * Failure: The test will fail if the device was not locked to the upstream GM in the last minute.
-    * Error: The test will error if the 'lastSyncTime' variable is not present in the command output.
+    * Skipped: The test will be skipped if PTP is not configured on the device.
 
     Examples
     --------
@@ -133,7 +133,7 @@ class VerifyPtpLockStatus(AntaTest):
         command_output = self.instance_commands[0].json_output
 
         if (ptp_clock_summary := command_output.get("ptpClockSummary")) is None:
-            self.result.is_error("'ptpClockSummary' variable is not present in the command output")
+            self.result.is_skipped("PTP is not configured")
             return
 
         time_difference = ptp_clock_summary["currentPtpSystemTime"] - ptp_clock_summary["lastSyncTime"]
@@ -151,7 +151,7 @@ class VerifyPtpOffset(AntaTest):
     ----------------
     * Success: The test will pass if the PTP timing offset is within +/- 1000ns from the master clock.
     * Failure: The test will fail if the PTP timing offset is greater than +/- 1000ns from the master clock.
-    * Skipped: The test will be skipped if PTP is not configured.
+    * Skipped: The test will be skipped if PTP is not configured on the device.
 
     Examples
     --------

--- a/tests/units/anta_tests/test_ptp.py
+++ b/tests/units/anta_tests/test_ptp.py
@@ -42,11 +42,11 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["The device is not configured as a PTP Boundary Clock: 'ptpDisabled'"]},
     },
     {
-        "name": "error",
+        "name": "skipped",
         "test": VerifyPtpModeStatus,
         "eos_data": [{"ptpIntfSummaries": {}}],
         "inputs": None,
-        "expected": {"result": "error", "messages": ["'ptpMode' variable is not present in the command output"]},
+        "expected": {"result": "skipped", "messages": ["PTP is not configured"]},
     },
     {
         "name": "success",
@@ -104,11 +104,11 @@ DATA: list[dict[str, Any]] = [
         },
     },
     {
-        "name": "error",
+        "name": "skipped",
         "test": VerifyPtpGMStatus,
         "eos_data": [{"ptpIntfSummaries": {}}],
         "inputs": {"gmid": "0xec:46:70:ff:fe:00:ff:a8"},
-        "expected": {"result": "error", "messages": ["'ptpClockSummary' variable is not present in the command output"]},
+        "expected": {"result": "skipped", "messages": ["PTP is not configured"]},
     },
     {
         "name": "success",
@@ -161,14 +161,14 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["The device lock is more than 60s old: 157s"]},
     },
     {
-        "name": "error",
+        "name": "skipped",
         "test": VerifyPtpLockStatus,
         "eos_data": [{"ptpIntfSummaries": {}}],
         "inputs": None,
         "expected": {
-            "result": "error",
+            "result": "skipped",
             "messages": [
-                "'ptpClockSummary' variable is not present in the command output",
+                "PTP is not configured",
             ],
         },
     },


### PR DESCRIPTION
# Description

PTP tests are not skipped when not configured on the device.

Fixes #608 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
