### PR TITLE
fix(anta.tests): Fix AVT and Path-Selection tests to be skipped on cEOSlab and vEOS-lab

### DIFF
--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 
 from pydantic import BaseModel
 
+from anta.decorators import skip_on_platforms
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.tools import get_value
 
@@ -38,6 +39,7 @@ class VerifyAVTPathHealth(AntaTest):
     categories: ClassVar[list[str]] = ["avt"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show adaptive-virtual-topology path")]
 
+    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyAVTPathHealth."""
@@ -126,6 +128,7 @@ class VerifyAVTSpecificPath(AntaTest):
         """Render the template for each input AVT path/peer."""
         return [template.render(vrf=path.vrf, avt_name=path.avt_name, destination=path.destination) for path in self.inputs.avt_paths]
 
+    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyAVTSpecificPath."""
@@ -216,6 +219,7 @@ class VerifyAVTRole(AntaTest):
         role: str
         """Expected AVT role of the device."""
 
+    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyAVTRole."""

--- a/anta/tests/path_selection.py
+++ b/anta/tests/path_selection.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 
 from pydantic import BaseModel
 
+from anta.decorators import skip_on_platforms
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.tools import get_value
 
@@ -42,6 +43,7 @@ class VerifyPathsHealth(AntaTest):
     categories: ClassVar[list[str]] = ["path-selection"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show path-selection paths", revision=1)]
 
+    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyPathsHealth."""
@@ -130,6 +132,7 @@ class VerifySpecificPath(AntaTest):
             template.render(peer=path.peer, group=path.path_group, source=path.source_address, destination=path.destination_address) for path in self.inputs.paths
         ]
 
+    @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifySpecificPath."""


### PR DESCRIPTION
# Description

<!-- PR description !-->

Fixes #670 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
