### PR TITLE
refactor: Extract regular expression to support regexp unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,23 @@ RUN pip install --upgrade pip
 WORKDIR /local
 COPY . /local
 
-ENV PYTHONPATH=/local
-ENV PATH=$PATH:/root/.local/bin
+RUN python -m venv /opt/venv
 
-RUN pip --no-cache-dir install --user .
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apk add --no-cache build-base # Add build-base package
+RUN pip --no-cache-dir install "." &&\
+    pip --no-cache-dir install ".[cli]"
 
 # ----------------------------------- #
 
 ### BASE
 
 FROM python:${PYTHON_VER}-${IMG_OPTION} AS BASE
+
+# Add a system user
+RUN adduser --system anta
 
 # Opencontainer labels
 # Labels version and revision will be updating
@@ -40,7 +47,12 @@ LABEL   "org.opencontainers.image.title"="anta" \
         "org.opencontainers.image.revision"="dev" \
         "org.opencontainers.image.version"="dev"
 
-COPY --from=BUILDER /root/.local/ /root/.local
-ENV PATH=$PATH:/root/.local/bin
+# Copy artifacts from builder
+COPY --from=BUILDER /opt/venv /opt/venv
 
-ENTRYPOINT [ "/root/.local/bin/anta" ]
+# Define PATH and default user
+ENV PATH="/opt/venv/bin:$PATH"
+
+USER anta
+
+ENTRYPOINT [ "/opt/venv/bin/anta" ]

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -18,6 +18,7 @@ from aioeapi import EapiCommandError
 from click.exceptions import UsageError
 from httpx import ConnectError, HTTPError
 
+from anta.custom_types import REGEXP_PATH_MARKERS
 from anta.device import AntaDevice, AsyncEOSDevice
 from anta.models import AntaCommand
 
@@ -60,7 +61,7 @@ async def collect_commands(
     async def collect(dev: AntaDevice, command: str, outformat: Literal["json", "text"]) -> None:
         outdir = Path() / root_dir / dev.name / outformat
         outdir.mkdir(parents=True, exist_ok=True)
-        safe_command = re.sub(r"(/|\|$)", "_", command)
+        safe_command = re.sub(rf"{REGEXP_PATH_MARKERS}", "_", command)
         c = AntaCommand(command=command, ofmt=outformat)
         await dev.collect(c)
         if not c.collected:

--- a/anta/models.py
+++ b/anta/models.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypeVar
 from pydantic import BaseModel, ConfigDict, ValidationError, create_model
 
 from anta import GITHUB_SUGGESTION
-from anta.custom_types import Revision
+from anta.custom_types import REGEXP_EOS_BLACKLIST_CMDS, Revision
 from anta.logger import anta_log_exception, exc_to_str
 from anta.result_manager.models import TestResult
 
@@ -31,9 +31,6 @@ F = TypeVar("F", bound=Callable[..., Any])
 # Proper way to type input class - revisit this later if we get any issue @gmuloc
 # This would imply overhead to define classes
 # https://stackoverflow.com/questions/74103528/type-hinting-an-instance-of-a-nested-class
-
-# TODO: make this configurable - with an env var maybe?
-BLACKLIST_REGEX = [r"^reload.*", r"^conf\w*\s*(terminal|session)*", r"^wr\w*\s*\w+"]
 
 logger = logging.getLogger(__name__)
 
@@ -515,12 +512,12 @@ class AntaTest(ABC):
         """Check if CLI commands contain a blocked keyword."""
         state = False
         for command in self.instance_commands:
-            for pattern in BLACKLIST_REGEX:
+            for pattern in REGEXP_EOS_BLACKLIST_CMDS:
                 if re.match(pattern, command.command):
                     self.logger.error(
                         "Command <%s> is blocked for security reason matching %s",
                         command.command,
-                        BLACKLIST_REGEX,
+                        REGEXP_EOS_BLACKLIST_CMDS,
                     )
                     self.result.is_error(f"<{command.command}> is blocked for security reason")
                     state = True

--- a/tests/units/test_custom_types.py
+++ b/tests/units/test_custom_types.py
@@ -10,9 +10,191 @@ TODO: Expand later.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
-from anta.custom_types import bgp_multiprotocol_capabilities_abbreviations, interface_autocomplete
+from anta.custom_types import (
+    REGEX_BGP_IPV4_MPLS_VPN,
+    REGEX_BGP_IPV4_UNICAST,
+    REGEXP_BGP_IPV4_MPLS_LABELS,
+    REGEXP_BGP_L2VPN_AFI,
+    REGEXP_EOS_BLACKLIST_CMDS,
+    REGEXP_INTERFACE_ID,
+    REGEXP_PATH_MARKERS,
+    REGEXP_TYPE_EOS_INTERFACE,
+    REGEXP_TYPE_HOSTNAME,
+    REGEXP_TYPE_VXLAN_SRC_INTERFACE,
+    aaa_group_prefix,
+    bgp_multiprotocol_capabilities_abbreviations,
+    interface_autocomplete,
+    interface_case_sensitivity,
+)
+
+# ------------------------------------------------------------------------------
+# TEST custom_types.py regular expressions
+# ------------------------------------------------------------------------------
+
+
+def test_regexp_path_markers() -> None:
+    """Test REGEXP_PATH_MARKERS."""
+    # Test strings that should match the pattern
+    assert re.search(REGEXP_PATH_MARKERS, "show/bgp/interfaces") is not None
+    assert re.search(REGEXP_PATH_MARKERS, "show\\bgp") is not None
+    assert re.search(REGEXP_PATH_MARKERS, "show bgp") is not None
+
+    # Test strings that should not match the pattern
+    assert re.search(REGEXP_PATH_MARKERS, "aaaa") is None
+    assert re.search(REGEXP_PATH_MARKERS, "11111") is None
+    assert re.search(REGEXP_PATH_MARKERS, ".[]?<>") is None
+
+
+def test_regexp_bgp_l2vpn_afi() -> None:
+    """Test REGEXP_BGP_L2VPN_AFI."""
+    # Test strings that should match the pattern
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2vpn-evpn") is not None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2 vpn evpn") is not None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2-vpn evpn") is not None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2vpn evpn") is not None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2vpnevpn") is not None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2 vpnevpn") is not None
+
+    # Test strings that should not match the pattern
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "al2vpn evpn") is None
+    assert re.search(REGEXP_BGP_L2VPN_AFI, "l2vpn-evpna") is None
+
+
+def test_regexp_bgp_ipv4_mpls_labels() -> None:
+    """Test REGEXP_BGP_IPV4_MPLS_LABELS."""
+    assert re.search(REGEXP_BGP_IPV4_MPLS_LABELS, "ipv4-mpls-label") is not None
+    assert re.search(REGEXP_BGP_IPV4_MPLS_LABELS, "ipv4 mpls labels") is not None
+    assert re.search(REGEXP_BGP_IPV4_MPLS_LABELS, "ipv4Mplslabel") is None
+
+
+def test_regex_bgp_ipv4_mpls_vpn() -> None:
+    """Test REGEX_BGP_IPV4_MPLS_VPN."""
+    assert re.search(REGEX_BGP_IPV4_MPLS_VPN, "ipv4-mpls-vpn") is not None
+    assert re.search(REGEX_BGP_IPV4_MPLS_VPN, "ipv4_mplsvpn") is None
+
+
+def test_regex_bgp_ipv4_unicast() -> None:
+    """Test REGEX_BGP_IPV4_UNICAST."""
+    assert re.search(REGEX_BGP_IPV4_UNICAST, "ipv4-uni-cast") is not None
+    assert re.search(REGEX_BGP_IPV4_UNICAST, "ipv4+unicast") is None
+
+
+def test_regexp_type_interface_id() -> None:
+    """Test REGEXP_INTERFACE_ID."""
+    intf_id_re = re.compile(f"{REGEXP_INTERFACE_ID}")
+
+    # Test strings that should match the pattern
+    assert intf_id_re.search("123") is not None
+    assert intf_id_re.search("123/456") is not None
+    assert intf_id_re.search("123.456") is not None
+    assert intf_id_re.search("123/456.789") is not None
+
+
+def test_regexp_type_eos_interface() -> None:
+    """Test REGEXP_TYPE_EOS_INTERFACE."""
+    # Test strings that should match the pattern
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Ethernet0") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Vlan100") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Port-Channel1/0") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Loopback0.1") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Management0/0/0") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Tunnel1") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Vxlan1") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Fabric1") is not None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Dps1") is not None
+
+    # Test strings that should not match the pattern
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Ethernet") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Vlan") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Port-Channel") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Loopback.") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Management/") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Tunnel") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Vxlan") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Fabric") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Dps") is None
+
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Ethernet1/a") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Port-Channel-100") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Loopback.10") is None
+    assert re.match(REGEXP_TYPE_EOS_INTERFACE, "Management/10") is None
+
+
+def test_regexp_type_vxlan_src_interface() -> None:
+    """Test REGEXP_TYPE_VXLAN_SRC_INTERFACE."""
+    # Test strings that should match the pattern
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback0") is not None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback1") is not None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback99") is not None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback100") is not None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback8190") is not None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback8199") is not None
+
+    # Test strings that should not match the pattern
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback") is None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback9001") is None
+    assert re.match(REGEXP_TYPE_VXLAN_SRC_INTERFACE, "Loopback9000") is None
+
+
+def test_regexp_type_hostname() -> None:
+    """Test REGEXP_TYPE_HOSTNAME."""
+    # Test strings that should match the pattern
+    assert re.match(REGEXP_TYPE_HOSTNAME, "hostname") is not None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "hostname.com") is not None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "host-name.com") is not None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "host.name.com") is not None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "host-name1.com") is not None
+
+    # Test strings that should not match the pattern
+    assert re.match(REGEXP_TYPE_HOSTNAME, "-hostname.com") is None
+    assert re.match(REGEXP_TYPE_HOSTNAME, ".hostname.com") is None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "hostname-.com") is None
+    assert re.match(REGEXP_TYPE_HOSTNAME, "hostname..com") is None
+
+
+def test_regexp_eos_blacklist_cmds() -> None:
+    """Test REGEXP_EOS_BLACKLIST_CMDS."""
+    # Test strings that should match the pattern
+    for pattern in REGEXP_EOS_BLACKLIST_CMDS:
+        assert re.match(pattern, "reload") is not None
+        assert re.match(pattern, "reload something") is not None
+        assert re.match(pattern, "config terminal") is not None
+        assert re.match(pattern, "config session") is not None
+        assert re.match(pattern, "write memory") is not None
+
+    # Test strings that should not match the pattern
+    for pattern in REGEXP_EOS_BLACKLIST_CMDS:
+        assert re.match(pattern, "load") is None
+        assert re.match(pattern, "terminal") is None
+        assert re.match(pattern, "session") is None
+        assert re.match(pattern, "memory") is None
+
+
+# ------------------------------------------------------------------------------
+# TEST custom_types.py functions
+# ------------------------------------------------------------------------------
+
+
+def test_interface_autocomplete_success() -> None:
+    """Test interface_autocomplete with valid inputs."""
+    assert interface_autocomplete("et1") == "Ethernet1"
+    assert interface_autocomplete("et1/1") == "Ethernet1/1"
+    assert interface_autocomplete("et1.1") == "Ethernet1.1"
+    assert interface_autocomplete("et1/1.1") == "Ethernet1/1.1"
+    assert interface_autocomplete("eth2") == "Ethernet2"
+    assert interface_autocomplete("po3") == "Port-Channel3"
+    assert interface_autocomplete("lo4") == "Loopback4"
+
+
+def test_interface_autocomplete_no_alias() -> None:
+    """Test interface_autocomplete with inputs that don't have aliases."""
+    assert interface_autocomplete("GigabitEthernet1") == "GigabitEthernet1"
+    assert interface_autocomplete("Vlan10") == "Vlan10"
+    assert interface_autocomplete("Tunnel100") == "Tunnel100"
 
 
 def test_interface_autocomplete_failure() -> None:
@@ -34,3 +216,37 @@ def test_interface_autocomplete_failure() -> None:
 def test_bgp_multiprotocol_capabilities_abbreviationsh(str_input: str, expected_output: str) -> None:
     """Test bgp_multiprotocol_capabilities_abbreviations."""
     assert bgp_multiprotocol_capabilities_abbreviations(str_input) == expected_output
+
+
+def test_aaa_group_prefix_known_method() -> None:
+    """Test aaa_group_prefix with a known method."""
+    assert aaa_group_prefix("local") == "local"
+    assert aaa_group_prefix("none") == "none"
+    assert aaa_group_prefix("logging") == "logging"
+
+
+def test_aaa_group_prefix_unknown_method() -> None:
+    """Test aaa_group_prefix with an unknown method."""
+    assert aaa_group_prefix("demo") == "group demo"
+    assert aaa_group_prefix("group1") == "group group1"
+
+
+def test_interface_case_sensitivity_lowercase() -> None:
+    """Test interface_case_sensitivity with lowercase inputs."""
+    assert interface_case_sensitivity("ethernet") == "Ethernet"
+    assert interface_case_sensitivity("vlan") == "Vlan"
+    assert interface_case_sensitivity("loopback") == "Loopback"
+
+
+def test_interface_case_sensitivity_mixed_case() -> None:
+    """Test interface_case_sensitivity with mixed case inputs."""
+    assert interface_case_sensitivity("Ethernet") == "Ethernet"
+    assert interface_case_sensitivity("Vlan") == "Vlan"
+    assert interface_case_sensitivity("Loopback") == "Loopback"
+
+
+def test_interface_case_sensitivity_uppercase() -> None:
+    """Test interface_case_sensitivity with uppercase inputs."""
+    assert interface_case_sensitivity("ETHERNET") == "ETHERNET"
+    assert interface_case_sensitivity("VLAN") == "VLAN"
+    assert interface_case_sensitivity("LOOPBACK") == "LOOPBACK"


### PR DESCRIPTION
# Description

Approach to support regular expression unit test. So it is easier to change a regexp and check if it is not broken.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
